### PR TITLE
Refactoring TextObject for Better Performance

### DIFF
--- a/src/main/engine/GfxController/headers/DummyGfxController.hpp
+++ b/src/main/engine/GfxController/headers/DummyGfxController.hpp
@@ -42,6 +42,8 @@ class DummyGfxController : public GfxController {
     GfxResult<GLuint> enableVertexAttArray(GLuint layout, size_t size);
     GfxResult<GLuint> disableVertexAttArray(GLuint layout);
     GfxResult<GLuint> drawTriangles(GLuint size);
+    void deleteVao(GLuint *vao);
+    void deleteBuffer(GLuint *bufferId);
     void clear(GfxClearMode clearMode);
     void update();
 };

--- a/src/main/engine/GfxController/headers/GfxController.hpp
+++ b/src/main/engine/GfxController/headers/GfxController.hpp
@@ -112,4 +112,6 @@ class GfxController {
     virtual GfxResult<GLuint> drawTriangles(GLuint size) = 0;
     virtual void clear(GfxClearMode clearMode) = 0;
     virtual void update() = 0;
+    virtual void deleteBuffer(GLuint *bufferId) = 0;
+    virtual void deleteVao(GLuint *vao) = 0;
 };

--- a/src/main/engine/GfxController/headers/OpenGlGfxController.hpp
+++ b/src/main/engine/GfxController/headers/OpenGlGfxController.hpp
@@ -45,6 +45,8 @@ class OpenGlGfxController : public GfxController {
     GfxResult<GLuint> enableVertexAttArray(GLuint layout, size_t size);
     GfxResult<GLuint> disableVertexAttArray(GLuint layout);
     GfxResult<GLuint> drawTriangles(GLuint size);
+    void deleteVao(GLuint *vao);
+    void deleteBuffer(GLuint *bufferId);
     void clear(GfxClearMode clearMode);
     void update();
     void updateOpenGl();

--- a/src/main/engine/GfxController/src/DummyGfxController.cpp
+++ b/src/main/engine/GfxController/src/DummyGfxController.cpp
@@ -166,3 +166,13 @@ void DummyGfxController::clear(GfxClearMode clearMode) {
         clearMode);
 }
 
+void DummyGfxController::deleteBuffer(GLuint *bufferId) {
+    printf("GfxController::deleteBuffer: %p\n",
+        bufferId);
+}
+
+void DummyGfxController::deleteVao(GLuint *vao) {
+    printf("GfxController::deleteBuffer: %p\n",
+        vao);
+}
+

--- a/src/main/engine/GfxController/src/OpenGlGfxController.cpp
+++ b/src/main/engine/GfxController/src/OpenGlGfxController.cpp
@@ -638,3 +638,18 @@ void OpenGlGfxController::clear(GfxClearMode clearMode) {
     glClear(clearVal);
 }
 
+void OpenGlGfxController::deleteBuffer(GLuint *bufferId) {
+    glDeleteBuffers(1, bufferId);
+    auto error = glGetError();
+    if (error != GL_NO_ERROR) {
+        fprintf(stderr, "OpenGlGfxController::deleteBuffer: Error %d\n", error);
+    }
+}
+
+void OpenGlGfxController::deleteVao(GLuint *vao) {
+    glDeleteVertexArrays(1, vao);
+    auto error = glGetError();
+    if (error != GL_NO_ERROR) {
+        fprintf(stderr, "OpenGlGfxController::deleteVao: Error %d\n", error);
+    }
+}

--- a/src/main/engine/GfxController/src/OpenGlGfxController.cpp
+++ b/src/main/engine/GfxController/src/OpenGlGfxController.cpp
@@ -638,6 +638,11 @@ void OpenGlGfxController::clear(GfxClearMode clearMode) {
     glClear(clearVal);
 }
 
+/**
+ * @brief Deletes a VBO object
+ * 
+ * @param bufferId pointer to VBO ID of buffer to delete
+ */
 void OpenGlGfxController::deleteBuffer(GLuint *bufferId) {
     glDeleteBuffers(1, bufferId);
     auto error = glGetError();
@@ -646,6 +651,11 @@ void OpenGlGfxController::deleteBuffer(GLuint *bufferId) {
     }
 }
 
+/**
+ * @brief Deletes a VAO object
+ * 
+ * @param vao pointer to VAO ID of VAO to delete
+ */
 void OpenGlGfxController::deleteVao(GLuint *vao) {
     glDeleteVertexArrays(1, vao);
     auto error = glGetError();
@@ -653,3 +663,4 @@ void OpenGlGfxController::deleteVao(GLuint *vao) {
         fprintf(stderr, "OpenGlGfxController::deleteVao: Error %d\n", error);
     }
 }
+

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -75,7 +75,8 @@ class GameInstance {
         string objectName);
     CameraObject *createCamera(GameObject *target, vec3 offset, GLfloat cameraAngle, GLfloat aspectRatio,
               GLfloat nearClipping, GLfloat farClipping);
-    TextObject *createText(string message, string fontPath, GLuint programId, string objectName);
+    TextObject *createText(string message, vec3 position, GLfloat scale, string fontPath, GLuint programId,
+        string objectName);
     int getWidth();
     int getHeight();
     vec3 getDirectionalLight();

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -202,12 +202,6 @@ int GameInstance::updateObjects() {
     vector<SceneObject *> deferredUpdates;
     for (auto it = sceneObjects_.begin(); it != sceneObjects_.end(); ++it) {
         if ((*it)->type() == ObjectType::CAMERA_OBJECT) (*it)->update();
-        else
-            deferredUpdates.push_back(*it);
-    }
-    // Update all other updates after
-    for (auto it = deferredUpdates.begin(); it != deferredUpdates.end(); ++it) {
-        (*it)->update();
     }
     return 0;
 }
@@ -257,9 +251,11 @@ CameraObject *GameInstance::createCamera(GameObject *target, vec3 offset, GLfloa
     return gameCamera;
 }
 
-TextObject *GameInstance::createText(string message, string fontPath, GLuint programId, string objectName) {
+TextObject *GameInstance::createText(string message, vec3 position, GLfloat scale, string fontPath, GLuint programId,
+    string objectName) {
     printf("GameInstance::createText: Creating TextObject %lu\n", sceneObjects_.size());
-    auto text = new TextObject(message, fontPath, programId, objectName, ObjectType::TEXT_OBJECT, gfxController_);
+    auto text = new TextObject(message, position, scale, fontPath, programId, objectName, ObjectType::TEXT_OBJECT,
+        gfxController_);
     sceneObjects_.push_back(text);
     return text;
 }

--- a/src/main/engine/SceneObject/headers/GameObject.hpp
+++ b/src/main/engine/SceneObject/headers/GameObject.hpp
@@ -27,13 +27,13 @@ class GameObject: public SceneObject {
     inline void setScale(GLfloat scale) { this->scale = scale; }
     inline void setDirectionalLight(vec3 directionalLight) { this->directionalLight = directionalLight; }
     inline void setLuminance(GLfloat luminance) { this->luminance = luminance; }
-    inline void setProgramId(GLuint programId) { this->programId = programId; }
+    inline void setProgramId(GLuint programId) { this->programId_ = programId; }
 
     // Getters
     inline GLfloat getScale() { return this->scale; }
     inline vec3 getDirectionalLight() { return this->directionalLight; }
     inline GLfloat getLuminance() { return this->luminance; }
-    inline GLuint getProgramId() { return this->programId; }
+    inline GLuint getProgramId() { return this->programId_; }
 
     // Special Getters
     inline Polygon *getModel() { return model; }

--- a/src/main/engine/SceneObject/headers/SceneObject.hpp
+++ b/src/main/engine/SceneObject/headers/SceneObject.hpp
@@ -23,7 +23,7 @@ class SceneObject {
     // Constructors
     inline explicit SceneObject(vec3 position, vec3 rotation, string objectName, GLfloat scale, GLuint programId,
         ObjectType type, GfxController *gfxController):
-            position(position), rotation(rotation), objectName(objectName), scale(scale), programId(programId),
+            position(position), rotation(rotation), objectName(objectName), scale(scale), programId_(programId),
             type_ { type }, gfxController_ { gfxController } {}
     inline explicit SceneObject(ObjectType type, string objectName, GfxController *gfxController): type_ { type },
         objectName { objectName }, gfxController_ { gfxController } {}
@@ -60,7 +60,7 @@ class SceneObject {
 
     const string objectName;
     GLfloat scale;
-    GLuint programId;
+    GLuint programId_;
     GLuint vao_;
     ObjectType type_;
 

--- a/src/main/engine/SceneObject/headers/TextObject.hpp
+++ b/src/main/engine/SceneObject/headers/TextObject.hpp
@@ -22,16 +22,14 @@
  * @param Bearing(ivec2) Offset from baseline to left/top of glyph
  * @param Advance(unsigned_int) Offset to advance to next glyph
  */
-typedef struct Character
-{
+typedef struct Character {
     unsigned int TextureID;  // ID handle of the glyph texture
     ivec2 Size;              // Size of glyph
     ivec2 Bearing;           // Offset from baseline to left/top of glyph
     unsigned int Advance;    // Offset to advance to next glyph
 } Character;
 
-class TextObject : public SceneObject
-{
+class TextObject : public SceneObject {
  public:
     // Constructors
     /// @todo Remove ObjectType - we render by camera now, so this isn't really needed...

--- a/src/main/engine/SceneObject/headers/TextObject.hpp
+++ b/src/main/engine/SceneObject/headers/TextObject.hpp
@@ -61,5 +61,4 @@ class TextObject : public SceneObject
     vector<GLuint> vbos_;
     unsigned int textureUniformId;
     map<GLchar, Character> characters;
-    GLfloat spaceSize_;
 };

--- a/src/main/engine/SceneObject/headers/TextObject.hpp
+++ b/src/main/engine/SceneObject/headers/TextObject.hpp
@@ -4,12 +4,13 @@
  * @brief TextObject is a GameObject; orthographically rendered on-screen text object
  * @version 0.1
  * @date 2023-07-28
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 #pragma once
 #include <string>
+#include <vector>
 #include <GameObject.hpp>
 #include <ft2build.h> //NOLINT
 #include FT_FREETYPE_H
@@ -21,35 +22,44 @@
  * @param Bearing(ivec2) Offset from baseline to left/top of glyph
  * @param Advance(unsigned_int) Offset to advance to next glyph
  */
-typedef struct Character {
+typedef struct Character
+{
     unsigned int TextureID;  // ID handle of the glyph texture
-    ivec2 Size;       // Size of glyph
-    ivec2 Bearing;    // Offset from baseline to left/top of glyph
+    ivec2 Size;              // Size of glyph
+    ivec2 Bearing;           // Offset from baseline to left/top of glyph
     unsigned int Advance;    // Offset to advance to next glyph
 } Character;
 
-class TextObject: public SceneObject {
+class TextObject : public SceneObject
+{
  public:
-        // Constructors
-        explicit TextObject(string message, string fontPath, GLuint programId, string objectName,
-              ObjectType type, GfxController *gfxController);
-        ~TextObject() override;
+    // Constructors
+    /// @todo Remove ObjectType - we render by camera now, so this isn't really needed...
+    explicit TextObject(string message, vec3 position, GLfloat scale, string fontPath, GLuint programId,
+        string objectName, ObjectType type, GfxController *gfxController);
+    ~TextObject() override;
 
-        // Setters
-        inline void setMessage(string message) { this->message_ = message; }
+    // Setters
+    void setMessage(string message);
 
-        // Getters
-        inline string getMessage() { return this->message_; }
+    // Getters
+    inline string getMessage() { return this->message_; }
 
-        // Render method
-        void render() override;
-        void update() override;
+    // Render method
+    void render() override;
+    void update() override;
+    void createMessage();
+    void initializeText();
+    void initializeShaderVars();
+
  private:
-        string message_;
-        string fontPath_;
-        int fontSize;
-        Polygon *poly_;
-        unsigned int VBO;
-        unsigned int textureUniformId;
-        map<GLchar, Character> characters;
+    string message_;
+    string fontPath_;
+    int fontSize;
+    Polygon *poly_;
+    vector<GLuint> vaos_;
+    vector<GLuint> vbos_;
+    unsigned int textureUniformId;
+    map<GLchar, Character> characters;
+    GLfloat spaceSize_;
 };

--- a/src/main/engine/SceneObject/src/CameraObject.cpp
+++ b/src/main/engine/SceneObject/src/CameraObject.cpp
@@ -50,6 +50,8 @@ void CameraObject::update() {
                 break;
         }
         // Send the VP matrix for the camera to its gameobjects
+        // Render the game objects
+        (*it)->update();
     }
 }
 

--- a/src/main/engine/SceneObject/src/GameObject.cpp
+++ b/src/main/engine/SceneObject/src/GameObject.cpp
@@ -45,12 +45,12 @@ GameObject::GameObject(Polygon *characterModel, vec3 position, vec3 rotation, GL
             vec3(0, 1, 0))  *glm::rotate(mat4(1.0f), glm::radians(rotation[2]),
             vec3(0, 0, 1));
     // Grab IDs for shared variables between app and program (shader)
-    modelId = gfxController_->getShaderVariable(programId, "model").get();
-    vpId = gfxController_->getShaderVariable(programId, "VP").get();
-    hasTextureId = gfxController_->getShaderVariable(programId, "hasTexture").get();
-    directionalLightId = gfxController_->getShaderVariable(programId, "directionalLight").get();
-    luminanceId = gfxController_->getShaderVariable(programId, "luminance").get();
-    rollOffId = gfxController_->getShaderVariable(programId, "rollOff").get();
+    modelId = gfxController_->getShaderVariable(programId_, "model").get();
+    vpId = gfxController_->getShaderVariable(programId_, "VP").get();
+    hasTextureId = gfxController_->getShaderVariable(programId_, "hasTexture").get();
+    directionalLightId = gfxController_->getShaderVariable(programId_, "directionalLight").get();
+    luminanceId = gfxController_->getShaderVariable(programId_, "luminance").get();
+    rollOffId = gfxController_->getShaderVariable(programId_, "rollOff").get();
     vpMatrix_ = mat4(1.0f);  // Default VP matrix to identity matrix
 }
 
@@ -100,7 +100,7 @@ void GameObject::render() {
     // Send GameObject to render method
     // Draw each shape individually
     for (int i = 0; i < model->numberOfObjects; i++) {
-        gfxController_->setProgram(programId);
+        gfxController_->setProgram(programId_);
         gfxController_->polygonRenderMode(RenderMode::FILL);
         // Update our model transformation matrices
         translateMatrix_ = glm::translate(mat4(1.0f), position);

--- a/src/main/engine/SceneObject/src/TextObject.cpp
+++ b/src/main/engine/SceneObject/src/TextObject.cpp
@@ -15,7 +15,7 @@ TextObject::TextObject(string message, vec3 position, GLfloat scale, string font
     string objectName, ObjectType type, GfxController *gfxController): SceneObject(position,
     vec3(0.0f, 0.0f, 0.0f), objectName, scale, programId, type, gfxController), message_  { message },
     fontPath_ { fontPath } {
-    printf("TextObject::TextObject: Creating message %s\n", message);
+    printf("TextObject::TextObject: Creating message %s\n", message.c_str());
     initializeShaderVars();
     initializeText();
     createMessage();
@@ -82,8 +82,6 @@ void TextObject::createMessage() {
         GLuint vao;
         gfxController_->initVao(&vao);
         gfxController_->bindVao(vao);
-        printf("TextObject::TextObject: Creating character %c at x: %f, y: %f\n",
-            character, x, y);
         GLuint vbo;
         gfxController_->generateBuffer(&vbo);
         gfxController_->bindBuffer(vbo);

--- a/src/main/engine/SceneObject/src/TextObject.cpp
+++ b/src/main/engine/SceneObject/src/TextObject.cpp
@@ -137,8 +137,14 @@ void TextObject::update() {
     render();
 }
 
-// Updating the message requires re-creating the object
+/**
+ * @brief Update the text object with a new message. If the incoming message is the same as the existing message, then
+ * the message is not updated.
+ * 
+ * @param message Incoming message to set TextObject to.
+ */
 void TextObject::setMessage(string message) {
+    if (!message.compare(message_)) return;
     // Perform cleanup on existing VAOs
     gfxController_->bindVao(0);
     for (auto vao : vaos_) {

--- a/src/main/engine/SceneObject/src/TextObject.cpp
+++ b/src/main/engine/SceneObject/src/TextObject.cpp
@@ -11,16 +11,26 @@
 
 #include <TextObject.hpp>
 
-/// @todo: Finish this code - lots of hard-coded values
-TextObject::TextObject(string message, string fontPath, GLuint programId, string objectName, ObjectType type,
-              GfxController *gfxController): SceneObject(vec3(300.0f, 300.0f, 0.0f), vec3(0.0f, 0.0f, 0.0f),
-    objectName, 1.0f, programId, type, gfxController), message_  { message }, fontPath_ { fontPath } {
-    mat4 projection = ortho(0.0f, static_cast<float>(1280), 0.0f, static_cast<float>(720));
-    cout << "Initializing text with message " << message << endl;
+TextObject::TextObject(string message, vec3 position, GLfloat scale, string fontPath, GLuint programId,
+    string objectName, ObjectType type, GfxController *gfxController): SceneObject(position,
+    vec3(0.0f, 0.0f, 0.0f), objectName, scale, programId, type, gfxController), message_  { message },
+    fontPath_ { fontPath } {
+    printf("TextObject::TextObject: Creating message %s\n", message);
+    initializeShaderVars();
+    initializeText();
+    createMessage();
+}
 
-    gfxController_->setProgram(programId);
-    auto projectionId = gfxController_->getShaderVariable(programId, "projection").get();
+/// @todo Resolution is hardcoded to 720p right now. Add functionality to change this on the fly. Will need to re-send
+/// projection matrix.
+void TextObject::initializeShaderVars() {
+    mat4 projection = ortho(0.0f, static_cast<float>(1280), 0.0f, static_cast<float>(720));
+    gfxController_->setProgram(programId_);
+    auto projectionId = gfxController_->getShaderVariable(programId_, "projection").get();
     gfxController_->sendFloatMatrix(projectionId, 1, glm::value_ptr(projection));
+}
+
+void TextObject::initializeText() {
     FT_Library ft;
     if (FT_Init_FreeType(&ft)) {
         std::cout << "ERROR::FREETYPE: Could not init FreeType Library" << std::endl;
@@ -63,31 +73,21 @@ TextObject::TextObject(string message, string fontPath, GLuint programId, string
     }
     FT_Done_Face(face);
     FT_Done_FreeType(ft);
-    gfxController_->initVao(&vao_);
-    gfxController_->bindVao(vao_);
-    gfxController_->generateBuffer(&VBO);
-    gfxController_->bindBuffer(VBO);
-    gfxController_->sendBufferData(sizeof(GLfloat) * 6 * 4, nullptr);
-    gfxController_->enableVertexAttArray(0, 4);
-    gfxController_->bindBuffer(0);
-    gfxController_->bindVao(0);
 }
 
-/// @todo Do something useful here
-TextObject::~TextObject() {
-}
-
-void TextObject::render() {
-    gfxController_->clear(GfxClearMode::DEPTH);
-    vec3 color = vec3(1.0f);
-    int x = this->position.x, y = this->position.y;
-    gfxController_->setProgram(programId);
-    gfxController_->polygonRenderMode(RenderMode::FILL);
-    auto textColorId = gfxController_->getShaderVariable(programId, "textColor").get();
-    gfxController_->sendFloatVector(textColorId, 1, &color[0]);
-    gfxController_->bindVao(vao_);
-    for (auto c = message_.begin(); c != message_.end(); c++) {
-        Character ch = characters[*c];
+void TextObject::createMessage() {
+    auto x = this->position.x, y = this->position.y;
+    // Use textures to create each character as an independent object
+    for (auto character : message_) {
+        GLuint vao;
+        gfxController_->initVao(&vao);
+        gfxController_->bindVao(vao);
+        printf("TextObject::TextObject: Creating character %c at x: %f, y: %f\n",
+            character, x, y);
+        GLuint vbo;
+        gfxController_->generateBuffer(&vbo);
+        gfxController_->bindBuffer(vbo);
+        Character ch = characters[character];
         GLfloat xpos = x + ch.Bearing.x * scale;
         GLfloat ypos = y - (ch.Size.y - ch.Bearing.y) * scale;
         GLfloat w = ch.Size.x * scale;
@@ -102,12 +102,34 @@ void TextObject::render() {
             xpos + w, ypos,       1.0f, 1.0f,
             xpos + w, ypos + h,   1.0f, 0.0f
         };
-        // Update polygon data for each character
-        // Set the current texture
+        gfxController_->sendBufferData(sizeof(GLfloat) * vertices.size(), &vertices[0]);
+        gfxController_->enableVertexAttArray(0, 4);
+        vaos_.push_back(vao);
+        // Update x/y
+        x = w == 0 ? x + static_cast<GLfloat>(ch.Advance / 100.0f) : xpos + w;
+    }
+    gfxController_->bindBuffer(0);
+    gfxController_->bindVao(0);
+}
+
+/// @todo Do something useful here
+TextObject::~TextObject() {
+}
+
+void TextObject::render() {
+    gfxController_->clear(GfxClearMode::DEPTH);
+    vec3 color = vec3(1.0f);
+    gfxController_->setProgram(programId_);
+    gfxController_->polygonRenderMode(RenderMode::FILL);
+    auto textColorId = gfxController_->getShaderVariable(programId_, "textColor").get();
+    gfxController_->sendFloatVector(textColorId, 1, &color[0]);
+    // Find a more clever solution
+    auto index = 0;
+    for (auto character : message_) {
+        gfxController_->bindVao(vaos_[index++]);
+        Character ch = characters[character];
         gfxController_->bindTexture(ch.TextureID);
-        gfxController_->updateBufferData(vertices, VBO);
         gfxController_->drawTriangles(6);
-        x += (ch.Advance >> 6) * scale;
     }
     gfxController_->bindVao(0);
     gfxController_->bindTexture(0);
@@ -115,4 +137,23 @@ void TextObject::render() {
 
 void TextObject::update() {
     render();
+}
+
+// Updating the message requires re-creating the object
+void TextObject::setMessage(string message) {
+    // Perform cleanup on existing VAOs
+    gfxController_->bindVao(0);
+    for (auto vao : vaos_) {
+        gfxController_->disableVertexAttArray(0);
+        gfxController_->deleteVao(&vao);
+    }
+    for (auto vbo : vbos_) {
+        gfxController_->deleteBuffer(&vbo);
+    }
+    vaos_.clear();
+    vaos_.shrink_to_fit();
+    vbos_.clear();
+    vbos_.shrink_to_fit();
+    message_ = message;
+    createMessage();
 }

--- a/src/main/engine/SceneObject/src/TextObject.cpp
+++ b/src/main/engine/SceneObject/src/TextObject.cpp
@@ -48,6 +48,7 @@ void TextObject::initializeText() {
                 continue;
             }
             GLuint textureId;
+            // Generate OpenGL textures for Freetype font rasterizations
             gfxController_->generateTexture(&textureId);
             gfxController_->bindTexture(textureId);
             gfxController_->sendTextureData(
@@ -100,6 +101,8 @@ void TextObject::createMessage() {
             xpos + w, ypos,       1.0f, 1.0f,
             xpos + w, ypos + h,   1.0f, 0.0f
         };
+
+        // Send VBO data for each character to the currently bound buffer
         gfxController_->sendBufferData(sizeof(GLfloat) * vertices.size(), &vertices[0]);
         gfxController_->enableVertexAttArray(0, 4);
         vaos_.push_back(vao);

--- a/src/main/engine/SceneObject/src/TextObject.cpp
+++ b/src/main/engine/SceneObject/src/TextObject.cpp
@@ -151,7 +151,6 @@ void TextObject::setMessage(string message) {
     // Perform cleanup on existing VAOs
     gfxController_->bindVao(0);
     for (auto vao : vaos_) {
-        gfxController_->disableVertexAttArray(0);
         gfxController_->deleteVao(&vao);
     }
     for (auto vbo : vbos_) {

--- a/src/main/example/src/game.cpp
+++ b/src/main/example/src/game.cpp
@@ -149,28 +149,42 @@ int runtime(GameInstance *currentGame) {
     wolfRef = wolfObject;
 
     // Configure some in-game text objects
-    auto engineText = currentGame->createText("Studious Engine 2024", "src/resources/fonts/AovelSans.ttf",
-        gfxController.getProgramId(2).get(), "studious-text");
-    engineText->setPosition(vec3(25.0f, 25.0f, 0.0f));
-    // Re-using gameObject 4 for no particular reason
-    auto contactText = currentGame->createText("Contact", "src/resources/fonts/AovelSans.ttf",
-        gfxController.getProgramId(2).get(), "contact-text");
+    auto engineText = currentGame->createText(
+        "Studious Engine 2024",                 // Message
+        vec3(25.0f, 25.0f, 0.0f),               // Position
+        1.0f,                                   // Scale
+        "src/resources/fonts/AovelSans.ttf",    // Font Path
+        gfxController.getProgramId(2).get(),    // ProgramId
+        "studious-text");                       // ObjectName
+
+    auto contactText = currentGame->createText(
+        "Contact",                              // Message
+        vec3(25.0f, 300.0f, 0.0f),              // Position
+        0.7f,                                   // Scale
+        "src/resources/fonts/AovelSans.ttf",    // Font Path
+        gfxController.getProgramId(2).get(),    // ProgramId
+        "contact-text");                        // ObjectName
+
     pressUText = currentGame->createText(
-        "Press 'U' to attach/detach mouse", "src/resources/fonts/AovelSans.ttf",
-        gfxController.getProgramId(2).get(), "contact-text");
-    contactText->setPosition(vec3(25.0f, 300.0f, 0.0f));
-    pressUText->setPosition(vec3(800.0f, 670.0f, 0.0f));
-    pressUText->setScale(0.7f);
+        "Press 'U' to attach/detach mouse",
+        vec3(800.0f, 670.0f, 0.0f),
+        0.7f,
+        "src/resources/fonts/AovelSans.ttf",
+        gfxController.getProgramId(2).get(),
+        "contact-text");
+
     collDebugText = contactText;
     collDebugText->setMessage("Contact: False");
-    collDebugText->setScale(0.7f);
 
-    auto fpsText = currentGame->createText("FPS", "src/resources/fonts/AovelSans.ttf",
-        gfxController.getProgramId(2).get(), "fps-text");
-    fpsText->setPosition(vec3(25.0f, 670.0f, 0.0f));
+    auto fpsText = currentGame->createText("FPS",
+        vec3(25.0f, 670.0f, 0.0f),
+        0.7f,
+        "src/resources/fonts/AovelSans.ttf",
+        gfxController.getProgramId(2).get(),
+        "fps-text");
+
     fps_counter = fpsText;
     fps_counter->setMessage("FPS: 0");
-    fps_counter->setScale(0.7f);
 
     auto currentCamera = currentGame->createCamera(playerRef,
         vec3(5.140022f, 1.349999f, 2.309998f), 3.14159 / 5.0f, 16.0f / 9.0f, 4.0f, 90.0f);
@@ -189,7 +203,8 @@ int runtime(GameInstance *currentGame) {
         wolfObject,
         engineText,
         contactText,
-        fpsText
+        fpsText,
+        pressUText
     };
 
     // Add all objects to active camera
@@ -241,14 +256,15 @@ int mainLoop(gameInfo* gamein) {
         if (error) {
             return error;
         }
-        collision = currentGame->getCollision(playerRef, wolfRef, vec3(0, 0, 0));
+        auto newCollision = currentGame->getCollision(playerRef, wolfRef, vec3(0, 0, 0));
         string collMessage;
-        if (collision == 1) {
+        if (newCollision == 1) {
             collMessage = "Contact: True";
         } else {
             collMessage = "Contact: False";
         }
-        collDebugText->setMessage(collMessage);
+        if (newCollision != collision) collDebugText->setMessage(collMessage);
+        collision = newCollision;
         end = SDL_GetPerformanceCounter();
         deltaTime = static_cast<double>(end - begin) / (SDL_GetPerformanceFrequency());
         currentGame->setDeltaTime(deltaTime);

--- a/src/main/example/src/game.cpp
+++ b/src/main/example/src/game.cpp
@@ -256,15 +256,14 @@ int mainLoop(gameInfo* gamein) {
         if (error) {
             return error;
         }
-        auto newCollision = currentGame->getCollision(playerRef, wolfRef, vec3(0, 0, 0));
+        collision = currentGame->getCollision(playerRef, wolfRef, vec3(0, 0, 0));
         string collMessage;
-        if (newCollision == 1) {
+        if (collision == 1) {
             collMessage = "Contact: True";
         } else {
             collMessage = "Contact: False";
         }
-        if (newCollision != collision) collDebugText->setMessage(collMessage);
-        collision = newCollision;
+        collDebugText->setMessage(collMessage);
         end = SDL_GetPerformanceCounter();
         deltaTime = static_cast<double>(end - begin) / (SDL_GetPerformanceFrequency());
         currentGame->setDeltaTime(deltaTime);

--- a/src/main/utilities/test/src/ModelImportTests.cpp
+++ b/src/main/utilities/test/src/ModelImportTests.cpp
@@ -22,12 +22,16 @@ using std::endl;
 class ModelImportTest: public ::testing::Test {
  protected:
     void SetUp() override {
-        auto dummyController = DummyGfxController();
-        modelImport = new ModelImport("dummy", texturePathStage, texturePatternStage, 0, &dummyController);
+        dummyController = new DummyGfxController();
+        modelImport = new ModelImport("dummy", texturePathStage, texturePatternStage, 0, dummyController);
+    }
+    void TearDown() override {
+        delete dummyController;
     }
     vector<string> texturePathStage;
     vector<GLint> texturePatternStage;
     ModelImport *modelImport;
+    DummyGfxController *dummyController;
 };
 
 /**


### PR DESCRIPTION
# Changes

### Context
<!--- Give a brief description of your changes. -->
Currently, adding TextObjects to a Game Scene dramatically decreases performance. This is because we re-create the vertex data for each glyph once per frame, requiring an expensive memory copy once per frame. These changes re-work the TextObject class, creating glyph meshes once when the object is created or when the message is set. This boosts the framerate up from 2700FPS to 8500FPS.
![Screenshot_20240421_124723](https://github.com/alec-jackson/studious-engine/assets/42315696/6e3ac55a-94bf-4ed1-99d3-3927d1565aec)

### Issues
<!--- List any relavant GitHub issues this PR is addressing here. -->
Resolves https://github.com/alec-jackson/studious-engine/issues/17. 
### Considerations
<!--- If any major decisions, breaking changes, or redesigns were made, describe them here. Give a brief summary describing how you came to this conclusion. -->
Added some cleanup methods to GfxController.
## QA Checklist

- [x] I ran `cpplint --linelength=120 --recursive src/main/` and corrected any issues.
- [x] I added unit tests to relevant code.
- [x] I added/revised Doxygen documentation on new code.

