### PR TITLE
Enabling VSYNC Through Config File

### DIFF
--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -17,6 +17,7 @@
 #include <GameObject.hpp>
 #include <CameraObject.hpp>
 #include <TextObject.hpp>
+#include <config.hpp>
 
 // Number of samples to use for anti-aliasing
 #define AASAMPLES 8
@@ -63,7 +64,7 @@ class GameInstance {
     mutex sceneLock_;
     bool audioInitialized_ = false;
 
-    void initWindow(int width, int height);
+    void initWindow(const configData &config);
     void initAudio();
     void initController();
     void initApplication(vector<string> vertexPath, vector<string> fragmentPath);
@@ -71,7 +72,7 @@ class GameInstance {
  public:
     GameInstance(vector<string> soundList, vector<string> vertShaders,
         vector<string> fragShaders, GfxController *gfxController, int width, int height);
-    void startGame();
+    void startGame(const configData &config);
     void stopGame();
     GameObject *createGameObject(Polygon *characterModel, vec3 position, vec3 rotation, float scale,
         string objectName);

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -33,8 +33,8 @@ GameInstance::GameInstance(vector<string> soundList, vector<string> vertShaders,
 }
 
 // Helper function for startup
-void GameInstance::startGame() {
-    initWindow(width_, height_);
+void GameInstance::startGame(const configData &config) {
+    initWindow(config);
     initAudio();
     // Comment out playSound to disable music
     playSound(0, 1);
@@ -322,10 +322,10 @@ void GameInstance::setLuminance(float luminanceValue) {
 
  (void) initWindow does not return any values.
 */
-void GameInstance::initWindow(int width, int height) {
+void GameInstance::initWindow(const configData &config) {
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK);
     window = SDL_CreateWindow("Studious Engine Example", SDL_WINDOWPOS_CENTERED,
-        SDL_WINDOWPOS_CENTERED, width, height,
+        SDL_WINDOWPOS_CENTERED, width_, height_,
         SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI);
 #ifndef GFX_EMBEDDED
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
@@ -343,7 +343,7 @@ void GameInstance::initWindow(int width, int height) {
     mainContext = SDL_GL_CreateContext(window);
     if (!mainContext) exit(EXIT_FAILURE);
 
-    SDL_GL_SetSwapInterval(0);  // 0 - Disable VSYNC / 1 - Enable VSYNC
+    SDL_GL_SetSwapInterval(config.enableVsync);  // 0 - Disable VSYNC / 1 - Enable VSYNC
     renderer = SDL_GetRenderer(window);
     if (window == NULL) {
         cerr << "Error: Failed to create SDL window!\n";

--- a/src/main/example/src/game.cpp
+++ b/src/main/example/src/game.cpp
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
         height = 720;
     }
     GameInstance currentGame(soundList, vertShaders, fragShaders, &gfxController, width, height);
-    currentGame.startGame();
+    currentGame.startGame(config);
     errorNum = runtime(&currentGame);
     return errorNum;
 }

--- a/src/main/misc/headers/config.hpp
+++ b/src/main/misc/headers/config.hpp
@@ -22,6 +22,7 @@
 typedef struct configData {
   int resX;
   int resY;
+  bool enableVsync;
 } configData;
 
 int loadConfig(configData* config, string filename);

--- a/src/main/misc/src/config.cpp
+++ b/src/main/misc/src/config.cpp
@@ -24,9 +24,9 @@ int loadConfig(configData* config, string filename) {
     if (file) {
         char buf[512];
         char convert[11];
-        int varSaves[2];
+        int varSaves[3];
         int retSize = 0;
-        int loops = 2;
+        int loops = 3;
         int offset = 0;
         retSize = SDL_RWread(file, buf, sizeof(char), 1024);
         for (int j = 0; j < loops; j++) {
@@ -51,9 +51,11 @@ int loadConfig(configData* config, string filename) {
             varSaves[j] = atoi(convert);
         }
         SDL_RWclose(file);
-        cout << "Resolution X: " << varSaves[0] << " Resolution Y: " << varSaves[1] << "\n";
+        printf("loadConfig: Resolution X: %d, Resolution Y: %d, VSYNC: %d\n",
+            varSaves[0], varSaves[1], varSaves[2]);
         config->resX = varSaves[0];
         config->resY = varSaves[1];
+        config->enableVsync = static_cast<bool>(varSaves[2]);
         return 0;
     } else {
         cout << "Could not open config file\n";

--- a/src/resources/config.txt
+++ b/src/resources/config.txt
@@ -1,2 +1,3 @@
 resX=1280
 resY=720
+enableVsync=1


### PR DESCRIPTION
# Changes

### Context
<!--- Give a brief description of your changes. -->
Adding the ability to enable/disable VSYNC via the configuration file.
### Issues
<!--- List any relavant GitHub issues this PR is addressing here. -->
None filed.
### Considerations
<!--- If any major decisions, breaking changes, or redesigns were made, describe them here. Give a brief summary describing how you came to this conclusion. -->
The engine example is extremely sluggish on MacOS when the frame rate is high and uncapped. The recent TextObject optimizations increased the frame rate by a factor of 3, but made the demo extremely choppy on MacOS. Enabling VSYNC fixes this issue.
## QA Checklist

- [x] I ran `cpplint --linelength=120 --recursive src/main/` and corrected any issues.
- [x] I added unit tests to relevant code. N/A
- [x] I added/revised Doxygen documentation on new code.N/A

