### PR TITLE
Fix Memory Leaks Across Studious

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_executable(${PROJECT_NAME}
   src/main/engine/SceneObject/src/GameObject2D.cpp
   src/main/engine/SceneObject/src/CameraObject.cpp
   src/main/engine/SceneObject/src/ColliderObject.cpp
+  src/main/utilities/src/GifLoader.cpp
   src/main/engine/Misc/src/inputMonitor.cpp
   src/main/engine/Misc/src/physics.cpp
   src/main/engine/GfxController/src/DummyGfxController.cpp

--- a/src/main/engine/AnimationController/headers/AnimationController.hpp
+++ b/src/main/engine/AnimationController/headers/AnimationController.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <functional>
 #include <mutex> // NOLINT
+#include <memory>
 #include <SceneObject.hpp>
 
 // Update return values

--- a/src/main/engine/AnimationController/headers/AnimationController.hpp
+++ b/src/main/engine/AnimationController/headers/AnimationController.hpp
@@ -81,7 +81,7 @@ typedef struct KeyFrames {
 
 class AnimationController {
  public:
-    int addKeyFrame(SceneObject *target, KeyFrame *keyFrame);
+    int addKeyFrame(SceneObject *target, std::shared_ptr<KeyFrame> keyFrame);
     void update();
     int updatePosition(SceneObject *target, KeyFrame *keyFrame);
     int updateRotation(SceneObject *target, KeyFrame *keyFrame);
@@ -89,8 +89,8 @@ class AnimationController {
     int updateStretch(SceneObject *target, KeyFrame *keyFrame);
     int updateText(SceneObject *target, KeyFrame *keyFrame);
     int updateTime(SceneObject *target, KeyFrame *keyFrame);
-    static KeyFrame *createKeyFrameCb(int type, ANIMATION_COMPLETE_CB, float time);
-    static KeyFrame *createKeyFrame(int type, float time);
+    static std::shared_ptr<KeyFrame> createKeyFrameCb(int type, ANIMATION_COMPLETE_CB, float time);
+    static std::shared_ptr<KeyFrame> createKeyFrame(int type, float time);
     static bool cap(float *cur, float target, float dv);
     UpdateData<vec3> updateVector(vec3 original, vec3 desired, vec3 current, KeyFrame *keyFrame);
     UpdateData<string> updateString(string original, string desired, string current, KeyFrame *keyFrame);

--- a/src/main/engine/GfxController/headers/GfxController.hpp
+++ b/src/main/engine/GfxController/headers/GfxController.hpp
@@ -91,7 +91,6 @@ class GfxController {
     virtual GfxResult<unsigned int> sendTextureData(unsigned int width, unsigned int height, TexFormat format,
         void *data) = 0;
     virtual GfxResult<int>  getShaderVariable(unsigned int, const char *) = 0;
-    virtual GfxResult<int>  cleanup() = 0;
     virtual GfxResult<unsigned int> getProgramId(uint) = 0;
     virtual GfxResult<unsigned int> setProgram(unsigned int) = 0;
     virtual GfxResult<unsigned int> loadShaders(string, string) = 0;

--- a/src/main/engine/GfxController/headers/OpenGlEsGfxController.hpp
+++ b/src/main/engine/GfxController/headers/OpenGlEsGfxController.hpp
@@ -14,6 +14,8 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <cstdint>
+#include <memory>
 #include <GfxController.hpp>
 #include <Polygon.hpp>
 #include <common.hpp>
@@ -59,7 +61,7 @@ class OpenGlEsGfxController : public GfxController {
     void clear(GfxClearMode clearMode);
     void update();
     void updateOpenGl();
-    unsigned char *convertToRgba(size_t size, unsigned char *data);
+    std::shared_ptr<uint8_t[]> convertToRgba(size_t size, uint8_t *data);
 
  private:
     vector<unsigned int> programIdList_;

--- a/src/main/engine/GfxController/headers/OpenGlGfxController.hpp
+++ b/src/main/engine/GfxController/headers/OpenGlGfxController.hpp
@@ -21,6 +21,8 @@
 
 class OpenGlGfxController : public GfxController {
  public:
+    OpenGlGfxController();
+    ~OpenGlGfxController();
     GfxResult<int> init();
     GfxResult<unsigned int> generateBuffer(unsigned int *bufferId);
     GfxResult<unsigned int> generateTexture(unsigned int *textureId);
@@ -56,4 +58,10 @@ class OpenGlGfxController : public GfxController {
 
  private:
     vector<unsigned int> programIdList_;
+    
+    /* Objects tracked internally to free when closing */
+    vector<unsigned int> vaoList_;
+    vector<unsigned int> vboList_;
+    vector<unsigned int> textureIdList_;
+
 };

--- a/src/main/engine/GfxController/headers/OpenGlGfxController.hpp
+++ b/src/main/engine/GfxController/headers/OpenGlGfxController.hpp
@@ -58,10 +58,9 @@ class OpenGlGfxController : public GfxController {
 
  private:
     vector<unsigned int> programIdList_;
-    
+
     /* Objects tracked internally to free when closing */
     vector<unsigned int> vaoList_;
     vector<unsigned int> vboList_;
     vector<unsigned int> textureIdList_;
-
 };

--- a/src/main/engine/GfxController/src/OpenGlGfxController.cpp
+++ b/src/main/engine/GfxController/src/OpenGlGfxController.cpp
@@ -141,21 +141,6 @@ GfxResult<unsigned int> OpenGlGfxController::generateTexture(unsigned int *textu
 }
 
 /**
- * @brief Cleans up OpenGL artifacts. Currently a WIP.
- * 
- * @return GfxResult<int> OK result containing the number of deleted programs.
- */
-GfxResult<int> OpenGlGfxController::cleanup() {
-    auto deletedPrograms = 0;
-    for (auto it = programIdList_.begin(); it != programIdList_.end(); ++it) {
-        glDeleteProgram(*it);
-        deletedPrograms++;
-    }
-    // glDeleteVertexArrays(1, &vertexArrayId_);
-    return GfxResult<int>(GfxApiResult::OK, deletedPrograms);
-}
-
-/**
  * @brief Gets a programId for a specific index in the programIdList.
  * 
  * @param index in the programId list

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <memory>
 #include <common.hpp>
 #include <ModelImport.hpp>
 #include <GameObject.hpp>

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -51,7 +51,7 @@ class GameInstance {
     SDL_Event event;
     SDL_GLContext mainContext;
     vector<Mix_Chunk *> sound;
-    vector<SceneObject *> sceneObjects_;
+    vector<std::shared_ptr<SceneObject>> sceneObjects_;
     vector<string> soundList_;
     vector<string> vertShaders_;
     vector<string> fragShaders_;
@@ -63,7 +63,7 @@ class GameInstance {
     vec3 directionalLight;
     float luminance;
     int width_, height_;
-    int audioID, controllersConnected;
+    int audioID, controllersConnected = 0;
     mutex sceneLock_;
     bool audioInitialized_ = false;
 
@@ -75,8 +75,8 @@ class GameInstance {
  public:
     GameInstance(vector<string> soundList, vector<string> vertShaders,
         vector<string> fragShaders, GfxController *gfxController, int width, int height);
+    ~GameInstance();
     void startGame(const configData &config);
-    void stopGame();
     GameObject *createGameObject(Polygon *characterModel, vec3 position, vec3 rotation, float scale,
         string objectName);
     CameraObject *createCamera(GameObject *target, vec3 offset, float cameraAngle, float aspectRatio,
@@ -100,7 +100,6 @@ class GameInstance {
     void changeVolume(int soundIndex, int volume);
     void stopSound(int channel);
     void changeWindowMode(int mode);
-    void cleanup();
     int destroySceneObject(SceneObject *object);
     SceneObject *getSceneObject(string objectName);
     int removeSceneObject(string objectName);

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -266,8 +266,8 @@ GameObject *GameInstance::createGameObject(Polygon *characterModel, vec3 positio
     string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
     printf("GameInstance::createGameObject: Creating GameObject %lu\n", sceneObjects_.size());
-    auto gameObject = std::make_shared<GameObject>(characterModel, position, rotation, scale, objectName, ObjectType::GAME_OBJECT,
-        gfxController_);
+    auto gameObject = std::make_shared<GameObject>(characterModel, position, rotation,
+        scale, objectName, ObjectType::GAME_OBJECT, gfxController_);
     gameObject.get()->setDirectionalLight(directionalLight);
     gameObject.get()->setLuminance(luminance);
     sceneObjects_.push_back(gameObject);
@@ -279,8 +279,8 @@ CameraObject *GameInstance::createCamera(GameObject *target, vec3 offset, float 
     std::unique_lock<std::mutex> lock(sceneLock_);
     printf("GameInstance::createCamera: Creating CameraObject %lu\n", sceneObjects_.size());
     auto cameraName = "Camera" + std::to_string(sceneObjects_.size());
-    auto gameCamera = std::make_shared<CameraObject>(target, offset, cameraAngle, aspectRatio, nearClipping, farClipping,
-        ObjectType::CAMERA_OBJECT, cameraName, gfxController_);
+    auto gameCamera = std::make_shared<CameraObject>(target, offset, cameraAngle,
+        aspectRatio, nearClipping, farClipping, ObjectType::CAMERA_OBJECT, cameraName, gfxController_);
     sceneObjects_.push_back(gameCamera);
     return gameCamera.get();
 }
@@ -289,8 +289,8 @@ TextObject *GameInstance::createText(string message, vec3 position, float scale,
     unsigned int programId, string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
     printf("GameInstance::createText: Creating TextObject %lu\n", sceneObjects_.size());
-    auto text = std::make_shared<TextObject>(message, position, scale, fontPath, programId, objectName, ObjectType::TEXT_OBJECT,
-        gfxController_);
+    auto text = std::make_shared<TextObject>(message, position, scale, fontPath,
+        programId, objectName, ObjectType::TEXT_OBJECT, gfxController_);
     sceneObjects_.push_back(text);
     return text.get();
 }

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -46,11 +46,6 @@ void GameInstance::startGame(const configData &config) {
     keystate = SDL_GetKeyboardState(NULL);
 }
 
-// Helper Function for teardown
-void GameInstance::stopGame() {
-    SDL_GL_DeleteContext(mainContext);
-}
-
 /*
  (int) getWidth returns the current width of the single window for the current
  GameInstance.
@@ -176,42 +171,21 @@ void GameInstance::changeWindowMode(int mode) {
     // SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 }
 
-/*
- (void) cleanup attempts to clean up dynamically allocated variables in the
- application, as well as other OpenGL variables created throughout the lifespan
- of the application.
-
- (void) cleanup does not return any value.
-*/
-void GameInstance::cleanup() {
-    printf("GameInstance::cleanup: Entry\n");
+GameInstance::~GameInstance() {
+    printf("GameInstance::~GameInstance\n");
     for (int i = 0; i < controllersConnected; i++) {
-        // SDL_GameControllerClose(gameControllers[i]);
+        SDL_GameControllerClose(gameControllers[i]);
     }
-    // Cleanup scene objects
-    for (auto it = sceneObjects_.begin(); it != sceneObjects_.end(); ++it) {
-        destroySceneObject(*it);
+    for (auto s : sound) {
+        Mix_FreeChunk(s);
     }
-    gfxController_->cleanup();
+    sound.clear();
+    soundList_.clear();
     Mix_CloseAudio();
+    SDL_GL_DeleteContext(mainContext);
     SDL_DestroyWindow(window);
     SDL_Quit();
     return;
-}
-/*
- (int) destroyGameObject takes a (GameObject *) object and attempts to clean up
- all dynamically allocated attributes for that given object.
-
- On success, 0 is returned and the memory used by that GameObject is freed. On
- failure, -1 is returned and an error is printed to stderr.
- */
-int GameInstance::destroySceneObject(SceneObject *object) {
-    if (object == nullptr) {
-        cerr << "Error: Cannot destroy empty GameObject!\n";
-        return -1;
-    }
-    delete object;
-    return 0;
 }
 
 /*
@@ -252,8 +226,8 @@ int GameInstance::updateObjects() {
     gfxController_->update();
     // Update cameras
     for (auto it = sceneObjects_.begin(); it != sceneObjects_.end(); ++it) {
-        if ((*it)->type() == ObjectType::CAMERA_OBJECT) {
-            CameraObject *cObj = static_cast<CameraObject *>(*it);
+        if ((*it).get()->type() == ObjectType::CAMERA_OBJECT) {
+            CameraObject *cObj = static_cast<CameraObject *>((*it).get());
             // Send the current screen resolution to the camera
             cObj->setResolution(this->getResolution());
             cObj->update();
@@ -292,12 +266,12 @@ GameObject *GameInstance::createGameObject(Polygon *characterModel, vec3 positio
     string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
     printf("GameInstance::createGameObject: Creating GameObject %lu\n", sceneObjects_.size());
-    auto gameObject = new GameObject(characterModel, position, rotation, scale, objectName, ObjectType::GAME_OBJECT,
+    auto gameObject = std::make_shared<GameObject>(characterModel, position, rotation, scale, objectName, ObjectType::GAME_OBJECT,
         gfxController_);
-    gameObject->setDirectionalLight(directionalLight);
-    gameObject->setLuminance(luminance);
+    gameObject.get()->setDirectionalLight(directionalLight);
+    gameObject.get()->setLuminance(luminance);
     sceneObjects_.push_back(gameObject);
-    return gameObject;
+    return gameObject.get();
 }
 
 CameraObject *GameInstance::createCamera(GameObject *target, vec3 offset, float cameraAngle, float aspectRatio,
@@ -305,73 +279,73 @@ CameraObject *GameInstance::createCamera(GameObject *target, vec3 offset, float 
     std::unique_lock<std::mutex> lock(sceneLock_);
     printf("GameInstance::createCamera: Creating CameraObject %lu\n", sceneObjects_.size());
     auto cameraName = "Camera" + std::to_string(sceneObjects_.size());
-    auto gameCamera = new CameraObject(target, offset, cameraAngle, aspectRatio, nearClipping, farClipping,
+    auto gameCamera = std::make_shared<CameraObject>(target, offset, cameraAngle, aspectRatio, nearClipping, farClipping,
         ObjectType::CAMERA_OBJECT, cameraName, gfxController_);
     sceneObjects_.push_back(gameCamera);
-    return gameCamera;
+    return gameCamera.get();
 }
 
 TextObject *GameInstance::createText(string message, vec3 position, float scale, string fontPath,
     unsigned int programId, string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
     printf("GameInstance::createText: Creating TextObject %lu\n", sceneObjects_.size());
-    auto text = new TextObject(message, position, scale, fontPath, programId, objectName, ObjectType::TEXT_OBJECT,
+    auto text = std::make_shared<TextObject>(message, position, scale, fontPath, programId, objectName, ObjectType::TEXT_OBJECT,
         gfxController_);
     sceneObjects_.push_back(text);
-    return text;
+    return text.get();
 }
 
 SpriteObject *GameInstance::createSprite(string spritePath, vec3 position, float scale, unsigned int programId,
     ObjectAnchor anchor, string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
-    auto sprite = new SpriteObject(spritePath, position, scale, programId, objectName,
+    auto sprite = std::make_shared<SpriteObject>(spritePath, position, scale, programId, objectName,
         ObjectType::GAME_OBJECT, anchor, gfxController_);
     sceneObjects_.push_back(sprite);
-    return sprite;
+    return sprite.get();
 }
 
 UiObject *GameInstance::createUi(string spritePath, vec3 position, float scale, float wScale, float hScale,
     unsigned int programId, ObjectAnchor anchor, string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
-    auto ui = new UiObject(spritePath, position, scale, wScale, hScale, programId, objectName,
+    auto ui = std::make_shared<UiObject>(spritePath, position, scale, wScale, hScale, programId, objectName,
         ObjectType::UI_OBJECT, anchor, gfxController_);
     sceneObjects_.push_back(ui);
-    return ui;
+    return ui.get();
 }
 
 SceneObject *GameInstance::getSceneObject(string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
     SceneObject *result = nullptr;
     for (auto it = sceneObjects_.begin(); it != sceneObjects_.end(); ++it) {
-        if ((*it)->getObjectName().compare(objectName) == 0) result = (*it);
+        if ((*it).get()->getObjectName().compare(objectName) == 0) result = (*it).get();
     }
     return result;
 }
 
 int GameInstance::removeSceneObject(string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
-    SceneObject *target = nullptr;
-    for (auto it = sceneObjects_.begin(); it != sceneObjects_.end(); ++it) {
-        if ((*it)->getObjectName().compare(objectName) == 0) target = (*it);
-    }
-    if (target == nullptr) {
+    // Search for the object by name
+    auto objectIt = std::find_if(sceneObjects_.begin(), sceneObjects_.end(),
+        [&objectName](std::shared_ptr<SceneObject> obj) {
+            return obj->getObjectName().compare(objectName) == 0;
+        });
+
+    if (objectIt == sceneObjects_.end()) {
         fprintf(stderr, "GameInstance::removeSceneObject: Not found (%s)\n",
             objectName.c_str());
         return -1;
-    }
-    // Remove the scene object from all cameras first...
-    for (auto it = sceneObjects_.begin(); it != sceneObjects_.end(); ++it) {
-        if ((*it)->type() == ObjectType::CAMERA_OBJECT) {
-            // Attempt to remove the object from the current camera
-            auto camera = static_cast<CameraObject *>(*it);
-            camera->removeSceneObject(target);
+    } else {
+        // This could be optimized a bit better - remove scene object from all cameras if found
+        for (auto it = sceneObjects_.begin(); it != sceneObjects_.end(); ++it) {
+            if ((*it).get()->type() == ObjectType::CAMERA_OBJECT) {
+                // Attempt to remove the object from the current camera
+                auto camera = static_cast<CameraObject *>((*it).get());
+                camera->removeSceneObject((*objectIt).get()->getObjectName());
+            }
         }
     }
 
-    sceneObjects_.erase(remove(sceneObjects_.begin(), sceneObjects_.end(), target), sceneObjects_.end());
-
-    // Free the memory for the deleted object
-    destroySceneObject(target);
+    sceneObjects_.erase(objectIt);
     return 0;
 }
 

--- a/src/main/engine/SceneObject/headers/CameraObject.hpp
+++ b/src/main/engine/SceneObject/headers/CameraObject.hpp
@@ -12,6 +12,7 @@
 #pragma once
 #include <vector>
 #include <string>
+#include <memory>
 #include <common.hpp>
 #include <GameObject.hpp>
 
@@ -35,7 +36,7 @@ class CameraObject : public SceneObject {
     void render() override;
     void update() override;
     void addSceneObject(SceneObject *gameObject);
-    void removeSceneObject(SceneObject *gameObject);
+    void removeSceneObject(string objectName);
 
  private:
     GameObject *target_;

--- a/src/main/engine/SceneObject/headers/ColliderObject.hpp
+++ b/src/main/engine/SceneObject/headers/ColliderObject.hpp
@@ -12,6 +12,7 @@
 #pragma once
 #include <vector>
 #include <string>
+#include <memory>
 #include <Polygon.hpp>
 #include <SceneObject.hpp>
 #include <GfxController.hpp>
@@ -36,7 +37,7 @@ class ColliderObject : public SceneObject {
     vec4 minPoints_;
     vec4 center_;
     vec4 originalCenter_;
-    Polygon *poly_ = nullptr;
+    std::shared_ptr<Polygon> poly_;
     Polygon *target_;
     // Create references to translate/scale matrices
     const mat4 &translateMatrix_;

--- a/src/main/engine/SceneObject/headers/GameObject.hpp
+++ b/src/main/engine/SceneObject/headers/GameObject.hpp
@@ -42,7 +42,6 @@ class GameObject: public SceneObject {
     float getColliderVertices(vector<float> vertices, int axis, bool (*test)(float a, float b));
 
     // Other methods
-    void deleteTextures();  /// @todo: DEPRECATED - Use destructor for this now...
     void createCollider(int programId);
     void configureOpenGl();
 
@@ -68,5 +67,5 @@ class GameObject: public SceneObject {
     vec3 directionalLight;
     vec3 velocity;
 
-    ColliderObject *collider_ = nullptr;
+    std::shared_ptr<ColliderObject> collider_;
 };

--- a/src/main/engine/SceneObject/headers/GameObject.hpp
+++ b/src/main/engine/SceneObject/headers/GameObject.hpp
@@ -12,6 +12,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <memory>
 #include <ModelImport.hpp>
 #include <SceneObject.hpp>
 #include <ColliderObject.hpp>

--- a/src/main/engine/SceneObject/headers/UiObject.hpp
+++ b/src/main/engine/SceneObject/headers/UiObject.hpp
@@ -12,6 +12,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <memory>
 #include <GameObject2D.hpp>
 #include <ColliderObject.hpp>
 
@@ -28,8 +29,8 @@ class UiObject : public GameObject2D {
     void update() override;
     void initializeShaderVars();
     void initializeVertexData();
-    float *generateVertices(float x, float y, float iFx, float iFy);
-    void generateVertexBase(float *vertexData, int triIdx, float x, float y, float x2, float y2);
+    std::shared_ptr<float[]> generateVertices(float x, float y, float iFx, float iFy);
+    void generateVertexBase(std::shared_ptr<float[]> vertexData, int triIdx, float x, float y, float x2, float y2);
 
     // Set scale methods
     void setHStretch(float scale);
@@ -42,7 +43,7 @@ class UiObject : public GameObject2D {
     unsigned int wScaleId_;
     unsigned int hScaleId_;
 
-    float *vertexData_;
+    std::shared_ptr<float[]> vertexData_;
 
     float wScale_;
     float hScale_;

--- a/src/main/engine/SceneObject/src/CameraObject.cpp
+++ b/src/main/engine/SceneObject/src/CameraObject.cpp
@@ -101,6 +101,11 @@ void CameraObject::addSceneObject(SceneObject *sceneObject) {
     sceneObjects_.push_back(sceneObject);
 }
 
-void CameraObject::removeSceneObject(SceneObject *gameObject) {
-    sceneObjects_.erase(remove(sceneObjects_.begin(), sceneObjects_.end(), gameObject), sceneObjects_.end());
+void CameraObject::removeSceneObject(string objectName) {
+    auto objectIt = std::find_if(sceneObjects_.begin(), sceneObjects_.end(),
+        [objectName](SceneObject *obj) {
+            return obj->getObjectName().compare(objectName) == 0;
+        });
+
+    sceneObjects_.erase(objectIt);
 }

--- a/src/main/engine/SceneObject/src/ColliderObject.cpp
+++ b/src/main/engine/SceneObject/src/ColliderObject.cpp
@@ -80,15 +80,15 @@ void ColliderObject::update() {
 }
 
 void ColliderObject::render() {
-    if (poly_->numberOfObjects > 0) {
-        gfxController_->setProgram(poly_->programId);
+    if (poly_.get()->numberOfObjects > 0) {
+        gfxController_->setProgram(poly_.get()->programId);
         gfxController_->polygonRenderMode(RenderMode::LINE);
         gfxController_->setCapability(GfxCapability::CULL_FACE, false);
         mat4 MVP = vpMatrix_ * translateMatrix_ * scaleMatrix_;
         gfxController_->sendFloatMatrix(mvpId_, 1, glm::value_ptr(MVP));
         // HINT: Render loops should really just be (bind Vao, draw triangles)
         gfxController_->bindVao(vao_);
-        gfxController_->drawTriangles(poly_->pointCount[0]);
+        gfxController_->drawTriangles(poly_.get()->pointCount[0]);
     }
 }
 
@@ -162,9 +162,9 @@ void ColliderObject::createCollider(unsigned int programId) {
         min[0], min[1], max[2]
     };
     auto pointCount = colliderVertices.size() / 3;
-    poly_ = new Polygon(pointCount, programId, colliderVertices);
-    gfxController_->generateBuffer(&poly_->shapeBufferId[0]);
-    gfxController_->bindBuffer(poly_->shapeBufferId[0]);
+    poly_ = std::make_shared<Polygon>(pointCount, programId, colliderVertices);
+    gfxController_->generateBuffer(&poly_.get()->shapeBufferId[0]);
+    gfxController_->bindBuffer(poly_.get()->shapeBufferId[0]);
     gfxController_->sendBufferData(sizeof(float) * colliderVertices.size(), &colliderVertices[0]);
     gfxController_->enableVertexAttArray(0, 3);
     // Set the correct center points
@@ -182,7 +182,6 @@ void ColliderObject::createCollider(unsigned int programId) {
 }
 
 ColliderObject::~ColliderObject() {
-    delete poly_;
 }
 
 float ColliderObject::getColliderVertices(vector<float> vertices, int axis,

--- a/src/main/engine/SceneObject/src/GameObject.cpp
+++ b/src/main/engine/SceneObject/src/GameObject.cpp
@@ -133,11 +133,7 @@ void GameObject::configureOpenGl() {
  * @brief GameObject destructor
  */
 GameObject::~GameObject() {
-    /// @todo: Run cleanup methods here
-    cout << "Destroying gameobject" << objectName << endl;
-    // Delete collider
-    if (collider_ != nullptr) delete collider_;
-    deleteTextures();
+    printf("GameObject::~GameObject\n");
 }
 
 /**
@@ -147,8 +143,8 @@ GameObject::~GameObject() {
  */
 ColliderObject *GameObject::getCollider(void) {
     // Update collider before returning it
-    collider_->updateCollider();
-    return collider_;
+    collider_.get()->updateCollider();
+    return collider_.get();
 }
 
 /**
@@ -159,7 +155,7 @@ ColliderObject *GameObject::getCollider(void) {
 void GameObject::createCollider(int programId) {
     printf("GameObject::createCollider: Creating collider for object %s\n", objectName.c_str());
     auto colliderName = objectName + "-Collider";
-    collider_ = new ColliderObject(this->getModel(), programId, translateMatrix_, scaleMatrix_, vpMatrix_,
+    collider_ = std::make_shared<ColliderObject>(this->getModel(), programId, translateMatrix_, scaleMatrix_, vpMatrix_,
         ObjectType::GAME_OBJECT, colliderName, gfxController_);
 }
 
@@ -204,17 +200,6 @@ void GameObject::render() {
         gfxController_->drawTriangles(model->pointCount[i] * 3);
         gfxController_->bindVao(0);
     }
-    if (collider_ != nullptr) collider_->update();
+    if (collider_.use_count() > 0) collider_.get()->update();
     }
-
-void GameObject::deleteTextures() {
-    if (model == nullptr) return;
-    cout << "GameObject::deleteTextures" << endl;
-    for (int i = 0; i < model->numberOfObjects; i++) {
-        if (hasTexture[i]) {
-            gfxController_->deleteTextures(&textureId);
-            hasTexture[i] = false;
-        }
-    }
-}
 

--- a/src/main/engine/SceneObject/src/TextObject.cpp
+++ b/src/main/engine/SceneObject/src/TextObject.cpp
@@ -53,7 +53,7 @@ void TextObject::initializeText() {
                 fprintf(stderr, "TextObject::initializeText: FREETYPE: Failed to load glyph\n");
                 continue;
             }
-            unsigned int textureId;
+            unsigned int textureId = 0;
             // Generate OpenGL textures for Freetype font rasterizations
             gfxController_->generateTexture(&textureId);
             gfxController_->bindTexture(textureId);

--- a/src/main/engine/SceneObject/src/UiObject.cpp
+++ b/src/main/engine/SceneObject/src/UiObject.cpp
@@ -35,7 +35,7 @@ void UiObject::initializeShaderVars() {
     gfxController_->sendFloatMatrix(modelMatId_, 1, glm::value_ptr(modelMat_));
 }
 
-void UiObject::generateVertexBase(float *vertexData, int triIdx, float x, float y, float x2, float y2) {
+void UiObject::generateVertexBase(std::shared_ptr<float[]> vertexData, int triIdx, float x, float y, float x2, float y2) {
     auto dT = (1.0f/3.0f);
     auto tX = (triIdx % 3) * dT;  // 0.33 target...
     auto tY = (triIdx / 3) * dT;
@@ -60,9 +60,9 @@ void UiObject::generateVertexBase(float *vertexData, int triIdx, float x, float 
     }
 }
 
-float *UiObject::generateVertices(float x, float y, float iFx, float iFy) {
+std::shared_ptr<float[]> UiObject::generateVertices(float x, float y, float iFx, float iFy) {
     // Allocate memory for vertex data
-    float *vertexData = new float[24 * 9];
+    std::shared_ptr<float[]> vertexData(new float[24 * 9], std::default_delete<float[]>());
 
     // Create the triangles from top left to right
     for (int i = 1; i < 4; ++i) {
@@ -105,13 +105,12 @@ void UiObject::initializeVertexData() {
 
     vertexData_ = generateVertices(x, y, incrementFactorX, incrementFactorY);
     // Send VBO data for each character to the currently bound buffer
-    gfxController_->sendBufferData(sizeof(float) * 24 * 9, vertexData_);
+    gfxController_->sendBufferData(sizeof(float) * 24 * 9, vertexData_.get());
     gfxController_->enableVertexAttArray(0, 4);
     gfxController_->bindBuffer(0);
     gfxController_->bindVao(0);
 }
 
-/// @todo Do something useful here
 UiObject::~UiObject() {
 }
 

--- a/src/main/engine/SceneObject/src/UiObject.cpp
+++ b/src/main/engine/SceneObject/src/UiObject.cpp
@@ -35,7 +35,8 @@ void UiObject::initializeShaderVars() {
     gfxController_->sendFloatMatrix(modelMatId_, 1, glm::value_ptr(modelMat_));
 }
 
-void UiObject::generateVertexBase(std::shared_ptr<float[]> vertexData, int triIdx, float x, float y, float x2, float y2) {
+void UiObject::generateVertexBase
+    (std::shared_ptr<float[]> vertexData, int triIdx, float x, float y, float x2, float y2) {
     auto dT = (1.0f/3.0f);
     auto tX = (triIdx % 3) * dT;  // 0.33 target...
     auto tY = (triIdx / 3) * dT;

--- a/src/main/example/src/game.cpp
+++ b/src/main/example/src/game.cpp
@@ -301,8 +301,6 @@ int runtime(GameInstance *currentGame) {
     mainLoop(&currentGameInfo);
     isDone = true;
     rotThread.join();
-    cout << "Running cleanup\n";
-    currentGame->cleanup();
     return 0;
 }
 

--- a/src/main/utilities/headers/GifLoader.hpp
+++ b/src/main/utilities/headers/GifLoader.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <map>
 #include <cstdint>
+#include <memory>
 
 #define GIF_HEADER_BLOCK_SIZE 6
 #define GIF_LOGICAL_SCREEN_DESCRIPTOR_SIZE 7
@@ -16,8 +17,6 @@
 
 using std::string;
 using std::vector;
-
-typedef unsigned char byte;
 
 enum GifVersion {
     GIFNONE,
@@ -35,31 +34,31 @@ struct Image {
     bool interlaceFlag;
     bool sortFlag;
     unsigned int lctSize;
-    byte *imageData;
+    std::shared_ptr<uint8_t[]> imageData;
 };
 
 class GifLoader {
  public:
     explicit inline GifLoader(string imagePath) : imagePath_ { imagePath } { loadGif(); }
     void loadGif();
-    GifVersion getVersionFromStr(const byte *versionStr);
-    uint16_t getCanvasWidthFromStr(const byte *lsd);
-    uint16_t getCanvasHeightFromStr(const byte *lsd);
-    byte getPackedFieldFromStr(const byte *lsd);
-    byte getBackgroundColorIndexFromStr(const byte *lsd);
-    byte getPixelAspectRatioFromStr(const byte *lsd);
-    void unpackFields(byte packedField);
+    GifVersion getVersionFromStr(const uint8_t *versionStr);
+    uint16_t getCanvasWidthFromStr(const uint8_t *lsd);
+    uint16_t getCanvasHeightFromStr(const uint8_t *lsd);
+    uint8_t getPackedFieldFromStr(const uint8_t *lsd);
+    uint8_t getBackgroundColorIndexFromStr(const uint8_t *lsd);
+    uint8_t getPixelAspectRatioFromStr(const uint8_t *lsd);
+    void unpackFields(uint8_t packedField);
     unsigned int processExtension(std::ifstream &inputFile);
     void processGraphicsControlExtension(std::ifstream &inputFile);
-    void unpackImageDescriptor(const byte *id, Image *im);
+    void unpackImageDescriptor(const uint8_t *id, Image *im);
     void parseImageData(std::ifstream &inputFile);
-    void lzwDecompression(byte lzwMin, std::vector<byte> data);
+    void lzwDecompression(uint8_t lzwMin, std::vector<uint8_t> data);
     void processColorOutputForImage(const std::vector<string> &outputData);
-    int initializeColorCodeTable(byte lzwMin);
-    void writeBufferToImage(byte *outBuffer, uint16_t fWidth, uint16_t fHeight, uint16_t iLeft,
+    unsigned int initializeColorCodeTable(uint8_t lzwMin);
+    void writeBufferToImage(uint8_t *outBuffer, uint16_t fWidth, uint16_t fHeight, uint16_t iLeft,
         uint16_t iTop, Image *im);
 
-    const Image &getImage(int imIndex) const;
+    const Image &getImage(unsigned int imIndex) const;
 
     inline GifVersion getVersion() { return version_; }
     inline uint16_t getCanvasWidth() { return canvasWidth_; }
@@ -68,12 +67,12 @@ class GifLoader {
     inline unsigned int getColorResolution() { return colorResolution_; }
     inline unsigned int getSortFlag() { return sortFlag_; }
     inline unsigned int getGlobalColorTableSize() { return globalColorTableSize_; }
-    inline byte getBackgroundColorIndex() { return backgroundColorIndex_; }
-    inline byte getPixelAspectRatio() { return pixelAspectRatio_; }
+    inline uint8_t getBackgroundColorIndex() { return backgroundColorIndex_; }
+    inline uint8_t getPixelAspectRatio() { return pixelAspectRatio_; }
 
-    inline byte getGceBlockSize() { return gceBlockSize_; }
+    inline uint8_t getGceBlockSize() { return gceBlockSize_; }
     inline uint16_t getGceDelayTime() { return gceDelayTime_; }
-    inline byte getGceTransparentColorIndex() { return gceTransparentColorIndex_; }
+    inline uint8_t getGceTransparentColorIndex() { return gceTransparentColorIndex_; }
     inline const vector<Image> &getImages() const { return images_; }
 
  private:
@@ -89,16 +88,16 @@ class GifLoader {
     unsigned int globalColorTableSize_;
 
     // GCE variables
-    byte gceBlockSize_;
+    uint8_t gceBlockSize_;
     uint16_t gceDelayTime_;
-    byte gceTransparentColorIndex_;
+    uint8_t gceTransparentColorIndex_;
 
-    byte backgroundColorIndex_;
-    byte pixelAspectRatio_;
+    uint8_t backgroundColorIndex_;
+    uint8_t pixelAspectRatio_;
 
     GifVersion version_;
 
-    byte *globalColorTable_ = nullptr;
+    std::shared_ptr<uint8_t> globalColorTable_;
     vector<Image> images_;
     vector<string> colorCodeTable_;
 };

--- a/src/main/utilities/src/GifLoader.cpp
+++ b/src/main/utilities/src/GifLoader.cpp
@@ -321,7 +321,8 @@ void GifLoader::processColorOutputForImage(const std::vector<string> &outputData
         memcpy(im.imageData.get(), outBuffer.get(), sizeof(outBuffer));
     } else {
         // Copy the last frame into the current image buffer
-        memcpy(im.imageData.get(), images_.at(images_.size() - 2).imageData.get(), sizeof(uint8_t) * width * height * 3);
+        memcpy(im.imageData.get(), images_.at(images_.size() - 2).imageData.get(),
+            sizeof(uint8_t) * width * height * 3);
 
         // Draw the output buffer on top of the previous frame
         writeBufferToImage(outBuffer.get(), width, height, im.imageLeft, im.imageTop, &im);

--- a/src/main/utilities/src/GifLoader.cpp
+++ b/src/main/utilities/src/GifLoader.cpp
@@ -30,8 +30,8 @@ void GifLoader::loadGif() {
     // Attempt to open the image at the provided path
     std::ifstream inputFile(imagePath_);
     // Todo - move these into their own functions
-    byte headerBlock[GIF_HEADER_BLOCK_SIZE];
-    byte logicalScreenDesc[GIF_LOGICAL_SCREEN_DESCRIPTOR_SIZE];
+    uint8_t headerBlock[GIF_HEADER_BLOCK_SIZE];
+    uint8_t logicalScreenDesc[GIF_LOGICAL_SCREEN_DESCRIPTOR_SIZE];
 
     if (inputFile.is_open()) {
         for (int i = 0; i < GIF_HEADER_BLOCK_SIZE; ++i) {
@@ -62,11 +62,11 @@ void GifLoader::loadGif() {
         auto gctSize = 1 << (globalColorTableSize_ + 1);
         gctSize *= 3;
         // Delete this when the object is destroyed
-        globalColorTable_ = new byte[gctSize];
+        globalColorTable_ = std::shared_ptr<uint8_t>(new uint8_t[gctSize], std::default_delete<uint8_t[]>());
         for (int i = 0; i < gctSize; ++i) {
             char readByte;
             inputFile.get(readByte);
-            globalColorTable_[i] = readByte;
+            globalColorTable_.get()[i] = readByte;
         }
         // Start creating each image
         while (!inputFile.eof()) {
@@ -80,7 +80,7 @@ void GifLoader::loadGif() {
                 printf("GifLoader::loadGif: End of file reached\n");
                 break;
             }
-            while ((byte)extCode == 0x21) {
+            while ((uint8_t)extCode == 0x21) {
                 // Undo the seek
                 inputFile.seekg(-1, std::ios::cur);
                 processExtension(inputFile);
@@ -90,7 +90,7 @@ void GifLoader::loadGif() {
             inputFile.seekg(-1, std::ios::cur);
 
             // Read the image descripter header
-            byte imageDescriptorHeader[GIF_IMAGE_DESCRIPTOR_SIZE];
+            uint8_t imageDescriptorHeader[GIF_IMAGE_DESCRIPTOR_SIZE];
             for (int i = 0; i < GIF_IMAGE_DESCRIPTOR_SIZE; ++i) {
                 char readByte;
                 inputFile.get(readByte);
@@ -119,22 +119,22 @@ void GifLoader::parseImageData(std::ifstream &inputFile) {
      // Actually parse image data now...
     char lzwMinByte;
     inputFile.get(lzwMinByte);
-    byte lzwMin = lzwMinByte;
+    uint8_t lzwMin = lzwMinByte;
 
     printf("GifLoader::lzwMin: %u\n", lzwMin);
 
     char readByte;
-    std::vector<byte> data;
+    std::vector<uint8_t> data;
     // Subblock loop
     while (inputFile.get(readByte)) {
         // This outer loop will check for the subblockSize
-        byte subblockSize = readByte;
+        uint8_t subblockSize = readByte;
         printf("GifLoader::parseImageData: subblock size: %u\n", subblockSize);
         // If the subblockSize is zero, then we break early because we're done reading data
         if (subblockSize == 0x00) break;
 
         // Otherwise, start another loop to read the entire subblock
-        for (byte i = 0; i < subblockSize; ++i) {
+        for (uint8_t i = 0; i < subblockSize; ++i) {
             inputFile.get(readByte);
             // Add the read byte to the data array
             data.push_back(readByte);
@@ -148,7 +148,7 @@ void GifLoader::parseImageData(std::ifstream &inputFile) {
     printf("\nIMAGE DATA END\n");
 }
 
-int GifLoader::initializeColorCodeTable(byte lzwMin) {
+unsigned int GifLoader::initializeColorCodeTable(uint8_t lzwMin) {
     // Clear out the color code table to reset it
     colorCodeTable_.clear();
     // Generate the code table using the lzw min
@@ -164,7 +164,7 @@ int GifLoader::initializeColorCodeTable(byte lzwMin) {
     return numberOfColors;
 }
 
-void GifLoader::lzwDecompression(byte lzwMin, vector<byte> data) {
+void GifLoader::lzwDecompression(uint8_t lzwMin, vector<uint8_t> data) {
     auto numberOfColors = initializeColorCodeTable(lzwMin);
     auto clearCodeIndex = numberOfColors;
     auto endOfInfoIndex = numberOfColors + 1;
@@ -289,14 +289,14 @@ void GifLoader::processColorOutputForImage(const std::vector<string> &outputData
         width = images_.at(images_.size() - 2).imageWidth;
         height = images_.at(images_.size() - 2).imageHeight;
     }
-    std::unique_ptr<byte[]> outBuffer(new byte[im.imageWidth * im.imageHeight * 3]);
+    std::unique_ptr<uint8_t[]> outBuffer(new uint8_t[im.imageWidth * im.imageHeight * 3]);
     // Ensure we have a previous full image to use as a reference
-    im.imageData = new byte[width * height * 3];
+    im.imageData = std::shared_ptr<uint8_t[]>(new uint8_t[width * height * 3], std::default_delete<uint8_t[]>());
     int currentColor = 0;
-    auto processOutput = [&] (string &outString, byte *outBuffer) {
+    auto processOutput = [&] (string &outString, uint8_t *outBuffer) {
         auto out = std::stoi(outString);
         // Copy the three corresponding color bytes from the gct into the image data
-        memcpy(&outBuffer[currentColor * 3], &globalColorTable_[out * 3], sizeof(byte) * 3);
+        memcpy(&outBuffer[currentColor * 3], &globalColorTable_.get()[out * 3], sizeof(uint8_t) * 3);
         currentColor++;
     };
     for (auto out : outputData) {
@@ -305,7 +305,7 @@ void GifLoader::processColorOutputForImage(const std::vector<string> &outputData
         for (auto c : out) {
             if (c == ';') {
                 // Process the output string
-                processOutput(s, outBuffer);
+                processOutput(s, outBuffer.get());
                 // clear string
                 s.clear();
             } else {
@@ -314,17 +314,17 @@ void GifLoader::processColorOutputForImage(const std::vector<string> &outputData
         }
         assert(s.empty() == false);
         // Process the output string s here again
-        processOutput(s, outBuffer);
+        processOutput(s, outBuffer.get());
     }
     // If we're doing a full image flush, then copy outbuffer to image data
     if (fullImageFlush) {
-        memcpy(im.imageData, outBuffer, sizeof(outBuffer));
+        memcpy(im.imageData.get(), outBuffer.get(), sizeof(outBuffer));
     } else {
         // Copy the last frame into the current image buffer
-        memcpy(im.imageData, images_.at(images_.size() - 2).imageData, sizeof(byte) * width * height * 3);
+        memcpy(im.imageData.get(), images_.at(images_.size() - 2).imageData.get(), sizeof(uint8_t) * width * height * 3);
 
         // Draw the output buffer on top of the previous frame
-        writeBufferToImage(outBuffer, width, height, im.imageLeft, im.imageTop, &im);
+        writeBufferToImage(outBuffer.get(), width, height, im.imageLeft, im.imageTop, &im);
     }
     // Update width/height values for subsequent images...
     im.imageWidth = width;
@@ -332,7 +332,7 @@ void GifLoader::processColorOutputForImage(const std::vector<string> &outputData
     printf("GifLoader::processColorOutputForImage: Complete!\n");
 }
 
-void GifLoader::writeBufferToImage(byte *outBuffer, uint16_t fWidth, uint16_t fHeight, uint16_t iLeft,
+void GifLoader::writeBufferToImage(uint8_t *outBuffer, uint16_t fWidth, uint16_t fHeight, uint16_t iLeft,
     uint16_t iTop, Image *im) {
     // Base case
     if (iTop - im->imageTop == im->imageHeight) return;
@@ -340,12 +340,12 @@ void GifLoader::writeBufferToImage(byte *outBuffer, uint16_t fWidth, uint16_t fH
     // Find the index in the buffer where we start writing
     auto startIdx = (iTop * fWidth + iLeft) * 3;
     // Perform a memcpy for the entire line from the output buffer
-    memcpy(&im->imageData[startIdx], outBuffer, sizeof(byte) * im->imageWidth * 3);
+    memcpy(&im->imageData[startIdx], outBuffer, sizeof(uint8_t) * im->imageWidth * 3);
     // Start the next iteration
     return writeBufferToImage(&outBuffer[im->imageWidth * 3], fWidth, fHeight, iLeft, iTop + 1, im);
 }
 
-void GifLoader::unpackImageDescriptor(const byte *id, Image *im) {
+void GifLoader::unpackImageDescriptor(const uint8_t *id, Image *im) {
     // Make sure the first byte is 2C
     assert(id[0] == 0x2C);
 
@@ -364,7 +364,7 @@ void GifLoader::unpackImageDescriptor(const byte *id, Image *im) {
     im->lctSize = id[9] & 0b00000111;
 }
 
-void GifLoader::unpackFields(byte packedField) {
+void GifLoader::unpackFields(uint8_t packedField) {
     // The most significant bit is the global color table flag
     globalColorTableFlag_ = (packedField & 0b10000000) >> 7;
     // The next three bits are the color resolution
@@ -375,7 +375,7 @@ void GifLoader::unpackFields(byte packedField) {
     globalColorTableSize_ = packedField & 0b00000111;
 }
 
-GifVersion GifLoader::getVersionFromStr(const byte *str) {
+GifVersion GifLoader::getVersionFromStr(const uint8_t *str) {
     GifVersion gifVersion = GIFNONE;
     if (str == nullptr) return gifVersion;
     // Check if the str matches any of the supported versions
@@ -389,12 +389,12 @@ GifVersion GifLoader::getVersionFromStr(const byte *str) {
     return gifVersion;
 }
 
-const Image &GifLoader::getImage(int imIndex) const {
-    assert(imIndex >= 0 && imIndex < images_.size());
+const Image &GifLoader::getImage(unsigned int imIndex) const {
+    assert(imIndex < images_.size());
     return images_.at(imIndex);
 }
 
-uint16_t GifLoader::getCanvasWidthFromStr(const byte *lsd) {
+uint16_t GifLoader::getCanvasWidthFromStr(const uint8_t *lsd) {
     uint16_t width = 0;
     // Sanity check
     if (lsd == nullptr) return width;
@@ -403,7 +403,7 @@ uint16_t GifLoader::getCanvasWidthFromStr(const byte *lsd) {
     return width;
 }
 
-uint16_t GifLoader::getCanvasHeightFromStr(const byte *lsd) {
+uint16_t GifLoader::getCanvasHeightFromStr(const uint8_t *lsd) {
     uint16_t height = 0;
     // Sanity check
     if (lsd == nullptr) return height;
@@ -412,8 +412,8 @@ uint16_t GifLoader::getCanvasHeightFromStr(const byte *lsd) {
     return height;
 }
 
-byte GifLoader::getPackedFieldFromStr(const byte *lsd) {
-    byte packedField = 0;
+uint8_t GifLoader::getPackedFieldFromStr(const uint8_t *lsd) {
+    uint8_t packedField = 0;
     // Sanity check
     if (lsd == nullptr) return packedField;
     // the packed field will be byte 4 in the LSD
@@ -421,15 +421,15 @@ byte GifLoader::getPackedFieldFromStr(const byte *lsd) {
     return packedField;
 }
 
-byte GifLoader::getBackgroundColorIndexFromStr(const byte *lsd) {
-    byte backgroundColorIndex = 0;
+uint8_t GifLoader::getBackgroundColorIndexFromStr(const uint8_t *lsd) {
+    uint8_t backgroundColorIndex = 0;
     if (lsd == nullptr) return backgroundColorIndex;
     backgroundColorIndex = lsd[5];
     return backgroundColorIndex;
 }
 
-byte GifLoader::getPixelAspectRatioFromStr(const byte *lsd) {
-    byte pixelAspectRatio = 0;
+uint8_t GifLoader::getPixelAspectRatioFromStr(const uint8_t *lsd) {
+    uint8_t pixelAspectRatio = 0;
     if (lsd == nullptr) return pixelAspectRatio;
     pixelAspectRatio = lsd[6];
     return pixelAspectRatio;
@@ -445,9 +445,9 @@ unsigned int GifLoader::processExtension(std::ifstream &inputFile) {
 
     char extensionLabel;
     inputFile.get(extensionLabel);
-    printf("GifLoader::processExtension: Processing extension %02x\n", (byte)extensionLabel);
+    printf("GifLoader::processExtension: Processing extension %02x\n", (uint8_t)extensionLabel);
 
-    if ((byte)extensionLabel != 0xF9) {
+    if ((uint8_t)extensionLabel != 0xF9) {
         printf("GifLabeL::processExtension: Ignoring non-graphics control extension\n");
         ignoreExtension = true;
     } else {
@@ -473,12 +473,12 @@ unsigned int GifLoader::processExtension(std::ifstream &inputFile) {
         appId[i] = readByte;
     }
 
-    if (memcmp(appId, "NETSCAPE2.0", blockSize) == 0) {
+    if (memcmp(appId.get(), "NETSCAPE2.0", blockSize) == 0) {
         printf("NETSCAPE EXTENSION FOUND, TRIGGERING SPECIAL BEHAVIOR\n");
         isNetscapeExt = true;
     }
 
-    printf("GifLoader::processExtension: appId = %s\n", appId);
+    printf("GifLoader::processExtension: appId = %s\n", appId.get());
     if (isNetscapeExt) {
         char bytesAfter;
         inputFile.get(bytesAfter);
@@ -497,16 +497,16 @@ unsigned int GifLoader::processExtension(std::ifstream &inputFile) {
         }
         printf("GifLoader::processExtension: Extension data is %d bytes long\n", byteCount);
         std::unique_ptr<char[]> debugData(new char[byteCount + 1]);
-        debugData[byteCount] = 0;
+        debugData.get()[byteCount] = 0;
         // Seek backwards
         inputFile.seekg(-1 * byteCount, std::ios::cur);
         // Now read those bytes into the buffer
         for (int i = 0; i < byteCount; ++i) {
             inputFile.get(readByte);
-            debugData[i] = readByte;
+            debugData.get()[i] = readByte;
         }
 
-        printf("GifLoader::processExtension: Extension data = %s\n", debugData);
+        printf("GifLoader::processExtension: Extension data = %s\n", debugData.get());
     }
 
     // Make sure the next byte we read is the terminator
@@ -527,7 +527,7 @@ void GifLoader::processGraphicsControlExtension(std::ifstream &inputFile) {
     inputFile.get(blockSize);
 
     // Set the block size
-    gceBlockSize_ = (byte) blockSize;
+    gceBlockSize_ = (uint8_t) blockSize;
 
     // Next byte is the packed field
     char packedField;
@@ -545,7 +545,7 @@ void GifLoader::processGraphicsControlExtension(std::ifstream &inputFile) {
     char transparentColorIndex;
     inputFile.get(transparentColorIndex);
 
-    gceTransparentColorIndex_ = (byte) transparentColorIndex;
+    gceTransparentColorIndex_ = (uint8_t) transparentColorIndex;
 
     char blockTerminator;
     inputFile.get(blockTerminator);


### PR DESCRIPTION
# Changes

### Context
<!--- Give a brief description of your changes. -->
There were substantial memory leaks in studious. These changes to the cleanup code should remove all of  them. Verified that no memory is leaked via valgrind. Have not validated changes on embedded code, will do so after #35 is completed. Moved to using smart pointers instead of new/delete pairs.
### Issues
<!--- List any relavant GitHub issues this PR is addressing here. -->
#16 
### Considerations
<!--- If any major decisions, breaking changes, or redesigns were made, describe them here. Give a brief summary describing how you came to this conclusion. -->
We should try sticking to only using c++ smart pointers for memory allocation from now on.

## QA Checklist

- [x] I ran `cpplint --linelength=120 --recursive src/main/` and corrected any issues.
- [ ] I added unit tests to relevant code.
- [ ] I added/revised Doxygen documentation on new code.

