### PR TITLE
Fixed 2D Sprite Anchoring

### DIFF
--- a/src/main/engine/GfxController/src/OpenGlEsGfxController.cpp
+++ b/src/main/engine/GfxController/src/OpenGlEsGfxController.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <vector>
 #include <cstdio>
+#include <memory>
 #include <OpenGlEsGfxController.hpp>
 
 /**

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -26,6 +26,8 @@
 // Number of samples to use for anti-aliasing
 #define AASAMPLES 8
 
+extern double deltaTime;
+
 /*
  controllerReadout is used for getting input from a controller. This struct
  will be used in conjunction with SDL_GameControllerGetAxis to get input from
@@ -58,7 +60,6 @@ class GameInstance {
     vector<string> fragShaders_;
     vector<string> texturePathStage_;
     vector<string> texturePath_;
-    double deltaTime;
     SDL_GameController *gameControllers[2];
     controllerReadout controllerInfo[2];
     vec3 directionalLight;
@@ -104,9 +105,7 @@ class GameInstance {
     int destroySceneObject(SceneObject *object);
     SceneObject *getSceneObject(string objectName);
     int removeSceneObject(string objectName);
-    double getDeltaTime();
     int getCollision(GameObject *object1, GameObject *object2, vec3 moving);
-    int setDeltaTime(double time);
     void setLuminance(float luminanceValue);
     void basicCollision(GameInstance* gameInstance);
     bool isWindowOpen();

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <memory>
 #include <GameInstance.hpp>
 
 /*

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -250,18 +250,6 @@ int GameInstance::updateWindow() {
     return 0;
 }
 
-/*
- (int) setDeltaTime takes a (double) time and sets the current GameInstance's
- deltaTime value to that time value. This time value should only ever be the
- amount of time in seconds passed since the last rendered frame.
-
- (int) setDeltaTime returns 0 upon success.
-*/
-int GameInstance::setDeltaTime(double time) {
-    deltaTime = time;
-    return 0;
-}
-
 GameObject *GameInstance::createGameObject(Polygon *characterModel, vec3 position, vec3 rotation, float scale,
     string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
@@ -347,14 +335,6 @@ int GameInstance::removeSceneObject(string objectName) {
 
     sceneObjects_.erase(objectIt);
     return 0;
-}
-
-/*
- (double) getDeltaTime returns the amount of time in second since the last
- rendered frame.
-*/
-double GameInstance::getDeltaTime() {
-    return deltaTime;
 }
 
 /*

--- a/src/main/engine/SceneObject/headers/SceneObject.hpp
+++ b/src/main/engine/SceneObject/headers/SceneObject.hpp
@@ -28,7 +28,8 @@ enum RenderPriority {
 
 enum ObjectAnchor {
     CENTER,
-    BOTTOM_LEFT
+    BOTTOM_LEFT,
+    TOP_LEFT
 };
 
 class SceneObject {

--- a/src/main/engine/SceneObject/src/ColliderObject.cpp
+++ b/src/main/engine/SceneObject/src/ColliderObject.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <string>
 #include <iostream>
+#include <memory>
 #include <ColliderObject.hpp>
 
 /** @todo Update - this is the old struct info

--- a/src/main/engine/SceneObject/src/GameObject.cpp
+++ b/src/main/engine/SceneObject/src/GameObject.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstdio>
 #include <iostream>
+#include <memory>
 #include <GameObject.hpp>
 
 /**

--- a/src/main/engine/SceneObject/src/GameObject2D.cpp
+++ b/src/main/engine/SceneObject/src/GameObject2D.cpp
@@ -62,28 +62,33 @@ void GameObject2D::initializeVertexData() {
             break;
         case CENTER:
             x = -1 * ((textureWidth_) / 2.0f);
-            y = (textureHeight_) / 2.0f;
+            y = -1 * ((textureHeight_) / 2.0f);
+            break;
+        case TOP_LEFT:
+            y = -1.0f * textureHeight_;
+            x = 0.0f;
             break;
         default:
             fprintf(stderr, "GameObject2D::initializeVertexData: Unsupported anchor type %d\n", anchor_);
             assert(false);
             break;
     }
-    auto x2 = x + (textureWidth_), y2 = y - (textureHeight_);
+    auto x2 = x + (textureWidth_), y2 = y + (textureHeight_);
     // Use textures to create each character as an independent object
     gfxController_->initVao(&vao_);
     gfxController_->bindVao(vao_);
     gfxController_->generateBuffer(&vbo_);
     gfxController_->bindBuffer(vbo_);
     // update VBO for each character
+    // UV coordinate origin STARTS in the TOP left, NOT BOTTOM LEFT!!!
     vector<float> vertices = {
-        x, y, 0.0f, 0.0f,
-        x, y2, 0.0f, 1.0f,
-        x2, y2, 1.0f, 1.0f,
+        x, y2, 0.0f, 0.0f,
+        x, y, 0.0f, 1.0f,
+        x2, y2, 1.0f, 0.0f,
 
-        x, y, 0.0f, 0.0f,
-        x2, y2, 1.0f, 1.0f,
-        x2, y, 1.0f, 0.0f
+        x2, y2, 1.0f, 0.0f,
+        x, y, 0.0f, 1.0f,
+        x2, y, 1.0f, 1.0f
     };
 
     // Send VBO data for each character to the currently bound buffer

--- a/src/main/engine/SceneObject/src/UiObject.cpp
+++ b/src/main/engine/SceneObject/src/UiObject.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <cstdio>
 #include <iostream>
+#include <memory>
 #include <UiObject.hpp>
 
 UiObject::UiObject(string spritePath, vec3 position, float scale, float wScale, float hScale, unsigned int programId,

--- a/src/main/example/src/game.cpp
+++ b/src/main/example/src/game.cpp
@@ -342,7 +342,6 @@ int mainLoop(gameInfo* gamein) {
         animationController.update();
         end = SDL_GetPerformanceCounter();
         deltaTime = static_cast<double>(end - begin) / (SDL_GetPerformanceFrequency());
-        currentGame->setDeltaTime(deltaTime);
         if (SHOW_FPS) {  // use sampleSize to find average FPS
             times.push_back(deltaTime);
             currentTime += deltaTime;


### PR DESCRIPTION
# Changes

### Context
<!--- Give a brief description of your changes. -->
Fixed 2D sprite anchoring. Currently, the BOTTOM_LEFT anchor would actually anchor to the top left. Placing an object with an ObjectAnchor at BOTTOM_LEFT with position 0,0,0 will now render it in the bottom left corner. Added a TOP_LEFT anchor for legacy sprite placement.

Changed deltaTime to be extern linked to GameInstance, rather than passed in.
### Issues
<!--- List any relavant GitHub issues this PR is addressing here. -->
No issues filed.
### Considerations
<!--- If any major decisions, breaking changes, or redesigns were made, describe them here. Give a brief summary describing how you came to this conclusion. -->
Games made with older versions of studious will need to change SpriteObject anchors to TOP_LEFT from BOTTOM_LEFT to keep the same exact sprite placement as before.
## QA Checklist

- [x] I ran `cpplint --linelength=120 --recursive src/main/` and corrected any issues.
- [x] I added unit tests to relevant code. N/A
- [x] I added/revised Doxygen documentation on new code.

