### PR TITLE
Add Cast from vector size to int

### DIFF
--- a/src/main/engine/SceneObject/src/ColliderObject.cpp
+++ b/src/main/engine/SceneObject/src/ColliderObject.cpp
@@ -45,7 +45,7 @@ ColliderObject::ColliderObject(const vector<float> &vertTexData, unsigned int pr
     // Separate vertex data from vertTexData
     assert(vertTexData.size() % 4 == 0);
     vector<float> vertices;
-    for (int i = 0; i < vertTexData.size(); ++i) {
+    for (uint i = 0; i < vertTexData.size(); ++i) {
         if (i % 4 == 3) continue;
         if (i % 4 == 2) {
             // Add a zero to the Z axis for 2D objects


### PR DESCRIPTION
The vector size to int implicit cast throws an error when compiled with werror and gcc. This just adds an explcit cast.

# Changes
Add an explicit cast

### Context
Werror fix on GCC 14.2.0

## QA Checklist

- [ ] I ran `cpplint --linelength=120 --recursive src/main/` and corrected any issues.
- [ ] I added unit tests to relevant code.
- [ ] I added/revised Doxygen documentation on new code.

