### PR TITLE
GCC 14.2 Fixes from RPI 4 xcompile

### DIFF
--- a/src/main/engine/GfxController/src/DummyGfxController.cpp
+++ b/src/main/engine/GfxController/src/DummyGfxController.cpp
@@ -30,7 +30,7 @@ GfxResult<unsigned int> DummyGfxController::bindBuffer(unsigned int bufferId) {
 }
 
 GfxResult<unsigned int> DummyGfxController::sendBufferData(size_t size, void *data) {
-    printf("GfxController::sendBufferData: size %ld, data %p\n", size, data);
+    printf("GfxController::sendBufferData: size %zu, data %p\n", size, data);
     return GFX_OK(unsigned int);
 }
 
@@ -81,7 +81,7 @@ GfxResult<unsigned int> DummyGfxController::sendFloat(unsigned int variableId, f
 }
 
 GfxResult<unsigned int> DummyGfxController::sendFloatVector(unsigned int variableId, size_t count, float *data) {
-    printf("GfxController::sendFloatVector: variableId=[%u], count=[%lu], data=[%p]\n",
+    printf("GfxController::sendFloatVector: variableId=[%u], count=[%zu], data=[%p]\n",
         variableId,
         count,
         data);
@@ -94,7 +94,7 @@ GfxResult<unsigned int> DummyGfxController::polygonRenderMode(RenderMode mode) {
 }
 
 GfxResult<unsigned int> DummyGfxController::sendFloatMatrix(unsigned int variableId, size_t count, float *data) {
-    printf("GfxController::sendFloatMatrix: variableId=[%u], count=[%lu], data=[%p]\n",
+    printf("GfxController::sendFloatMatrix: variableId=[%u], count=[%zu], data=[%p]\n",
         variableId,
         count,
         data);
@@ -149,7 +149,7 @@ GfxResult<unsigned int> DummyGfxController::generateMipMap() {
 }
 
 GfxResult<unsigned int> DummyGfxController::enableVertexAttArray(unsigned int layout, size_t size) {
-    printf("GfxController::enableVertexAttArray: layout %d, size %ld\n",
+    printf("GfxController::enableVertexAttArray: layout %d, size %zu\n",
         layout, size);
     return GFX_OK(unsigned int);
 }

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -254,7 +254,7 @@ int GameInstance::updateWindow() {
 GameObject *GameInstance::createGameObject(Polygon *characterModel, vec3 position, vec3 rotation, float scale,
     string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
-    printf("GameInstance::createGameObject: Creating GameObject %lu\n", sceneObjects_.size());
+    printf("GameInstance::createGameObject: Creating GameObject %zu\n", sceneObjects_.size());
     auto gameObject = std::make_shared<GameObject>(characterModel, position, rotation,
         scale, objectName, ObjectType::GAME_OBJECT, gfxController_);
     gameObject.get()->setDirectionalLight(directionalLight);
@@ -266,7 +266,7 @@ GameObject *GameInstance::createGameObject(Polygon *characterModel, vec3 positio
 CameraObject *GameInstance::createCamera(GameObject *target, vec3 offset, float cameraAngle, float aspectRatio,
               float nearClipping, float farClipping) {
     std::unique_lock<std::mutex> lock(sceneLock_);
-    printf("GameInstance::createCamera: Creating CameraObject %lu\n", sceneObjects_.size());
+    printf("GameInstance::createCamera: Creating CameraObject %zu\n", sceneObjects_.size());
     auto cameraName = "Camera" + std::to_string(sceneObjects_.size());
     auto gameCamera = std::make_shared<CameraObject>(target, offset, cameraAngle,
         aspectRatio, nearClipping, farClipping, ObjectType::CAMERA_OBJECT, cameraName, gfxController_);
@@ -277,7 +277,7 @@ CameraObject *GameInstance::createCamera(GameObject *target, vec3 offset, float 
 TextObject *GameInstance::createText(string message, vec3 position, float scale, string fontPath,
     unsigned int programId, string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
-    printf("GameInstance::createText: Creating TextObject %lu\n", sceneObjects_.size());
+    printf("GameInstance::createText: Creating TextObject %zu\n", sceneObjects_.size());
     auto text = std::make_shared<TextObject>(message, position, scale, fontPath,
         programId, objectName, ObjectType::TEXT_OBJECT, gfxController_);
     sceneObjects_.push_back(text);

--- a/src/main/engine/SceneObject/src/ColliderObject.cpp
+++ b/src/main/engine/SceneObject/src/ColliderObject.cpp
@@ -45,7 +45,7 @@ ColliderObject::ColliderObject(const vector<float> &vertTexData, unsigned int pr
     // Separate vertex data from vertTexData
     assert(vertTexData.size() % 4 == 0);
     vector<float> vertices;
-    for (int i = 0; i < vertTexData.size(); ++i) {
+    for (uint i = 0; i < vertTexData.size(); ++i) {
         if (i % 4 == 3) continue;
         if (i % 4 == 2) {
             // Add a zero to the Z axis for 2D objects


### PR DESCRIPTION
# Changes
Fixes type compares and prints

### Context
GCC 14.2 with Werror returns errors on some platforms. This fixes the ones presented with a yocto RPI xcompile

### Considerations
This does make use of the zu printf type which will break some older compilers. However it has been standard for over a decade now.

## QA Checklist

- [X] I ran `cpplint --linelength=120 --recursive src/main/` and corrected any issues.
- [ ] I added unit tests to relevant code.
- [ ] I added/revised Doxygen documentation on new code.

