### PR TITLE
Add Install Rule to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,3 +159,6 @@ target_link_libraries(${PROJECT_NAME} Threads::Threads)
 target_link_libraries(${PROJECT_NAME} ${FREETYPE_LIBRARIES})
 
 set_target_properties(${PROJECT_NAME} PROPERTIES XCODE_ATTRIBUTE_CONFIGURATION_BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+
+install(TARGETS ${PROJECT_NAME})


### PR DESCRIPTION
Adds a basic install to the cmake file this is necessary for the yocto package to deploy. It won't have any affect on normal operation as unless you invoke the install rule when you're building it will continue to run as normal.

# Changes
Adds a bare minimum install rule. We'll probably want to revisit this later

### Context
To create a package from build you need to have artifacts. Since we weren't installing anything we couldn't create a deb off our build and yocto would fail to deploy anything with studious in it.

## QA Checklist

- [ ] I ran `cpplint --linelength=120 --recursive src/main/` and corrected any issues.
- [ ] I added unit tests to relevant code.
- [ ] I added/revised Doxygen documentation on new code.

