### PR TITLE
Animation Track Class Re-Basing + Async Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ engineExample
 engineExample.xcodeproj/*
 *.log
 studious-*ExampleScene
+.cache
 
 # Cmake Temp Files #
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(${PROJECT_NAME} SHARED
   src/main/engine/GfxController/src/OpenGlEsGfxController.cpp
   src/main/engine/AnimationController/src/AnimationController.cpp
   src/main/engine/Misc/src/DeltaTime.cpp
+  src/main/engine/Misc/src/Image.cpp
   src/main/misc/src/config.cpp
 )
 
@@ -154,7 +155,7 @@ target_include_directories(gtest_PolygonTests
   PUBLIC ${FREETYPE_INCLUDE_DIRS}
 )
 
-target_link_libraries(gtest_PolygonTests 
+target_link_libraries(gtest_PolygonTests
   PUBLIC SDL2::Main
   PUBLIC SDL2::Mixer
   PUBLIC SDL2::Image
@@ -174,6 +175,8 @@ add_executable(gtest_SpriteObjectTests
   src/main/engine/SceneObject/src/GameObject2D.cpp
   src/main/engine/SceneObject/src/ColliderObject.cpp
   src/main/utilities/src/Polygon.cpp
+  src/main/engine/Misc/src/Image.cpp
+  src/main/engine/SceneObjectExt/src/TrackExt.cpp
 )
 
 target_include_directories(gtest_SpriteObjectTests
@@ -199,6 +202,8 @@ add_executable(gtest_AnimationControllerTests
   src/main/engine/SceneObject/src/UiObject.cpp
   src/main/utilities/src/Polygon.cpp
   src/main/engine/Misc/src/DeltaTime.cpp
+  src/main/engine/SceneObjectExt/src/TrackExt.cpp
+  src/main/engine/Misc/src/Image.cpp
 )
 
 target_include_directories(gtest_AnimationControllerTests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ include_directories(
   src/main/engine/AnimationController/headers
   src/main/engine/Misc/headers
   src/main/engine/SceneObject/headers
+  src/main/engine/SceneObjectExt/headers
   src/main/misc/headers
 )
 
@@ -71,6 +72,7 @@ add_library(${PROJECT_NAME} SHARED
   src/main/engine/SceneObject/src/GameObject2D.cpp
   src/main/engine/SceneObject/src/CameraObject.cpp
   src/main/engine/SceneObject/src/ColliderObject.cpp
+  src/main/engine/SceneObjectExt/src/TrackExt.cpp
   src/main/utilities/src/GifLoader.cpp
   src/main/engine/Misc/src/inputMonitor.cpp
   src/main/engine/Misc/src/physics.cpp
@@ -239,6 +241,7 @@ install (FILES
   src/main/engine/SceneObject/headers/SpriteObject.hpp
   src/main/engine/SceneObject/headers/TextObject.hpp
   src/main/engine/SceneObject/headers/UiObject.hpp
+  src/main/engine/SceneObjectExt/headers/TrackExt.hpp
   src/main/engine/GfxController/headers/GfxController.hpp
   src/main/engine/GfxController/headers/OpenGlEsGfxController.hpp
   src/main/engine/GfxController/headers/OpenGlGfxController.hpp

--- a/examples/2dDemo/game.cpp
+++ b/examples/2dDemo/game.cpp
@@ -147,7 +147,7 @@ int runtime(GameInstance *currentGame) {
     auto obstacle = currentGame->createSprite("src/resources/images/dot_image.png",
         vec3(300, 500, 0), 10, gfxController.getProgramId(3).get(), ObjectAnchor::CENTER, "obstacle");
 
-    obstacle->splitGrid(5, 4, 24);
+    obstacle->createAnimation(5, 4, 24);
     obstacle->createCollider(gfxController.getProgramId(1).get());
 
     /* Create an animation track for the obstacle */

--- a/examples/2dDemo/game.cpp
+++ b/examples/2dDemo/game.cpp
@@ -205,7 +205,6 @@ int runtime(GameInstance *currentGame) {
 */
 int mainLoop(gameInfo* gamein) {
     Uint64 begin, end;
-    int running = 1;
     double currentTime = 0.0, sampleTime = 1.0;
     GameInstance *currentGame = gamein->currentGame;
     int error = 0;
@@ -216,17 +215,15 @@ int mainLoop(gameInfo* gamein) {
     vec3 offset;
     vec3 newPos;
     bool eDown = false;
-    while (running) {
+    while (!currentGame->isShutDown()) {
         offset = vec3(0);
         /// @todo Move these calls to a separate thread...
         begin = SDL_GetPerformanceCounter();
-        running = currentGame->isWindowOpen();
-        error = currentGame->updateObjects();
-        error |= currentGame->updateWindow();
+        if (currentGame->getKeystate()[SDL_SCANCODE_ESCAPE]) currentGame->shutdown();
+        error = currentGame->update();
         if (error) {
             return error;
         }
-        animationController.update();
         end = SDL_GetPerformanceCounter();
         if (currentGame->getKeystate()[SDL_SCANCODE_W]) offset += vec3(0, speed, 0);
         if (currentGame->getKeystate()[SDL_SCANCODE_S]) offset -= vec3(0, speed, 0);

--- a/examples/2dDemo/game.cpp
+++ b/examples/2dDemo/game.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
         width = 1280;
         height = 720;
     }
-    GameInstance currentGame(vertShaders, fragShaders, &gfxController, width, height);
+    GameInstance currentGame(vertShaders, fragShaders, &gfxController, &animationController, width, height);
     currentGame.startGame(config);
     errorNum = runtime(&currentGame);
     return errorNum;

--- a/examples/3dDemoScene/game.cpp
+++ b/examples/3dDemoScene/game.cpp
@@ -253,12 +253,12 @@ int runtime(GameInstance *currentGame) {
 
     auto testUi = currentGame->createUi(
         "src/resources/images/Message Bubble UI.png",   // image path
-        vec3(20, 100, 0),                     // Position
+        vec3(150.0f, 145.0f, 0.0f),                     // Position
         0.5f,                                           // Scale
-        200.0f,                                         // Width
+        100.0f,                                         // Width
         0.0f,                                           // Height
         gfxController.getProgramId(4).get(),            // Shader pair
-        ObjectAnchor::BOTTOM_LEFT,                           // Anchor
+        ObjectAnchor::CENTER,                           // Anchor
         "uiBubble");                                    // UI Bubble
     auto testText = currentGame->createText(
         "Textbox Example",

--- a/examples/3dDemoScene/game.cpp
+++ b/examples/3dDemoScene/game.cpp
@@ -253,12 +253,12 @@ int runtime(GameInstance *currentGame) {
 
     auto testUi = currentGame->createUi(
         "src/resources/images/Message Bubble UI.png",   // image path
-        vec3(150.0f, 145.0f, 0.0f),                     // Position
+        vec3(20, 100, 0),                     // Position
         0.5f,                                           // Scale
-        100.0f,                                         // Width
+        200.0f,                                         // Width
         0.0f,                                           // Height
         gfxController.getProgramId(4).get(),            // Shader pair
-        ObjectAnchor::CENTER,                           // Anchor
+        ObjectAnchor::BOTTOM_LEFT,                           // Anchor
         "uiBubble");                                    // UI Bubble
     auto testText = currentGame->createText(
         "Textbox Example",

--- a/examples/3dDemoScene/game.cpp
+++ b/examples/3dDemoScene/game.cpp
@@ -208,27 +208,30 @@ int runtime(GameInstance *currentGame) {
     auto engineText = currentGame->createText(
         "Studious Engine 2025",                 // Message
         vec3(25.0f, 25.0f, 0.0f),               // Position
-        0.5f,                                   // Scale
+        1.0f,                                   // Scale
         "src/resources/fonts/AovelSans.ttf",    // Font Path
         5.0f,                                   // Char spacing
+        48,
         gfxController.getProgramId(2).get(),    // ProgramId
         "studious-text");                       // ObjectName
 
     auto contactText = currentGame->createText(
         "Contact",                              // Message
         vec3(25.0f, 300.0f, 0.0f),              // Position
-        0.35f,                                   // Scale
+        0.7f,                                   // Scale
         "src/resources/fonts/AovelSans.ttf",    // Font Path
         0.0f,                                   // Char spacing
+        48,
         gfxController.getProgramId(2).get(),    // ProgramId
         "contact-text");                        // ObjectName
 
     pressUText = currentGame->createText(
         "Press 'U' to attach/detach mouse",
         vec3(800.0f, 670.0f, 0.0f),
-        0.35f,
+        0.7f,
         "src/resources/fonts/AovelSans.ttf",
         0.0f,
+        48,
         gfxController.getProgramId(2).get(),
         "contact-text");
 
@@ -237,9 +240,10 @@ int runtime(GameInstance *currentGame) {
 
     auto fpsText = currentGame->createText("FPS",
         vec3(25.0f, 670.0f, 0.0f),
-        0.35f,
+        0.7f,
         "src/resources/fonts/AovelSans.ttf",
         0.0f,
+        48,
         gfxController.getProgramId(2).get(),
         "fps-text");
 
@@ -253,9 +257,9 @@ int runtime(GameInstance *currentGame) {
 
     auto testUi = currentGame->createUi(
         "src/resources/images/Message Bubble UI.png",   // image path
-        vec3(150.0f, 145.0f, 0.0f),                     // Position
+        vec3(80.0f, 160.0f, 0.0f),                     // Position
         0.5f,                                           // Scale
-        100.0f,                                         // Width
+        115.0f,                                         // Width
         0.0f,                                           // Height
         gfxController.getProgramId(4).get(),            // Shader pair
         ObjectAnchor::CENTER,                           // Anchor
@@ -263,9 +267,10 @@ int runtime(GameInstance *currentGame) {
     auto testText = currentGame->createText(
         "Textbox Example",
         vec3(40.0f, 155.0f, 0.0f),
-        0.3f,
+        0.6f,
         "src/resources/fonts/AovelSans.ttf",
-        0.0f,
+        1.0f,
+        48,
         gfxController.getProgramId(2).get(),
         "test-text");
 

--- a/examples/3dDemoScene/game.cpp
+++ b/examples/3dDemoScene/game.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
         width = 1280;
         height = 720;
     }
-    GameInstance currentGame(vertShaders, fragShaders, &gfxController, width, height);
+    GameInstance currentGame(vertShaders, fragShaders, &gfxController, &animationController, width, height);
     currentGame.startGame(config);
     errorNum = runtime(&currentGame);
     return errorNum;

--- a/examples/3dDemoScene/game.cpp
+++ b/examples/3dDemoScene/game.cpp
@@ -333,17 +333,15 @@ int runtime(GameInstance *currentGame) {
 */
 int mainLoop(gameInfo* gamein) {
     Uint64 begin, end;
-    int running = 1, collision = 0;
+    int collision = 0;
     double currentTime = 0.0, sampleTime = 1.0;
     GameInstance *currentGame = gamein->currentGame;
     int error = 0;
     vector<double> times;
-    while (running) {
-        /// @todo Move these calls to a separate thread...
+    while (!currentGame->isShutDown()) {
         begin = SDL_GetPerformanceCounter();
-        running = currentGame->isWindowOpen();
-        error = currentGame->updateObjects();
-        error |= currentGame->updateWindow();
+        if (currentGame->getKeystate()[SDL_SCANCODE_ESCAPE]) currentGame->shutdown();
+        error = currentGame->update();
         if (error) {
             return error;
         }
@@ -355,7 +353,6 @@ int mainLoop(gameInfo* gamein) {
             collMessage = "Contact: False";
         }
         collDebugText->setMessage(collMessage);
-        animationController.update();
         end = SDL_GetPerformanceCounter();
         deltaTime = static_cast<double>(end - begin) / (SDL_GetPerformanceFrequency());
         if (SHOW_FPS) {  // use sampleSize to find average FPS

--- a/src/main/engine/AnimationController/headers/AnimationController.hpp
+++ b/src/main/engine/AnimationController/headers/AnimationController.hpp
@@ -143,6 +143,10 @@ class AnimationController {
     UpdateData<float> updateFloat(float original, float desired, float current, KeyFrame *keyFrame);
     void playTrack(string trackName);
     void pauseTrack(string trackName);
+    /**
+    * @brief Removes a scene object from all track and key frame stores in the AnimationController.
+    * @param objectName Name of the object to remove from the AnimationController.
+    */
     void removeSceneObject(string objectName);
 
     // Getters for testing

--- a/src/main/engine/AnimationController/headers/AnimationController.hpp
+++ b/src/main/engine/AnimationController/headers/AnimationController.hpp
@@ -18,7 +18,7 @@
 #include <mutex> // NOLINT
 #include <memory>
 #include <vector>
-#include <GameObject2D.hpp>
+#include <TrackExt.hpp>
 #include <UiObject.hpp>
 #include <TextObject.hpp>
 
@@ -84,7 +84,7 @@ struct TrackConfiguration {
  * @brief Contains a set of tracks for a target object.
  */
 struct TrackStoreEntry {
-    GameObject2D *target;
+    TrackExt *target;
     std::shared_ptr<TrackConfiguration> track;
 };
 
@@ -99,8 +99,8 @@ struct ActiveTrackEntry {
     float sequenceTime;
     float currentTime = 0.0f;
     int currentTrackIdx;
-    GameObject2D *target;
-    inline ActiveTrackEntry(std::shared_ptr<TrackConfiguration> tr, float sPF, float sT, int cTI, GameObject2D *ta) :
+    TrackExt *target;
+    inline ActiveTrackEntry(std::shared_ptr<TrackConfiguration> tr, float sPF, float sT, int cTI, TrackExt *ta) :
         track { tr }, secondsPerFrame { sPF }, sequenceTime { sT }, currentTrackIdx { cTI }, target { ta } {};
 };
 
@@ -126,7 +126,7 @@ struct KeyFrames {
 class AnimationController {
  public:
     int addKeyFrame(SceneObject *target, std::shared_ptr<KeyFrame> keyFrame);
-    void addTrack(GameObject2D *target, string trackName, vector<int> trackData, int fps, bool loop);
+    void addTrack(TrackExt *target, string trackName, vector<int> trackData, int fps, bool loop);
     void update();
     int updatePosition(SceneObject *target, KeyFrame *keyFrame);
     int updateRotation(SceneObject *target, KeyFrame *keyFrame);
@@ -143,6 +143,7 @@ class AnimationController {
     UpdateData<float> updateFloat(float original, float desired, float current, KeyFrame *keyFrame);
     void playTrack(string trackName);
     void pauseTrack(string trackName);
+    void removeSceneObject(string objectName);
 
     // Getters for testing
     inline const std::map<string, KeyFrames> &getKeyFrameStore() { return keyFrameStore_; }

--- a/src/main/engine/AnimationController/headers/AnimationController.hpp
+++ b/src/main/engine/AnimationController/headers/AnimationController.hpp
@@ -45,7 +45,7 @@
 #define CAP_NEG 2
 #define NUM_AXIS 3
 #define ANIMATION_COMPLETE_CB std::function<void(void)> callback
-
+// Address all of the memory ownership problems too
 extern double deltaTime;
 
 template <typename T>

--- a/src/main/engine/AnimationController/headers/AnimationController.hpp
+++ b/src/main/engine/AnimationController/headers/AnimationController.hpp
@@ -4,9 +4,9 @@
  * @brief Global animation controller for SceneObjects
  * @version 0.1
  * @date 2024-10-20
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 
 #pragma once
@@ -45,7 +45,7 @@
 #define CAP_NEG 2
 #define NUM_AXIS 3
 #define ANIMATION_COMPLETE_CB std::function<void(void)> callback
-// Address all of the memory ownership problems too
+
 extern double deltaTime;
 
 template <typename T>

--- a/src/main/engine/AnimationController/headers/AnimationController.hpp
+++ b/src/main/engine/AnimationController/headers/AnimationController.hpp
@@ -144,11 +144,10 @@ class AnimationController {
     void playTrack(string trackName);
     void pauseTrack(string trackName);
     /**
-    * @brief Removes a scene object from all track and key frame stores in the AnimationController.
-    * @param objectName Name of the object to remove from the AnimationController.
-    */
+     * @brief Removes a scene object from all track and key frame stores in the AnimationController.
+     * @param objectName Name of the object to remove from the AnimationController.
+     */
     void removeSceneObject(string objectName);
-
     // Getters for testing
     inline const std::map<string, KeyFrames> &getKeyFrameStore() { return keyFrameStore_; }
     inline const std::map<string, TrackStoreEntry> &getTrackStore() { return trackStore_; }

--- a/src/main/engine/AnimationController/headers/AnimationController.hpp
+++ b/src/main/engine/AnimationController/headers/AnimationController.hpp
@@ -18,7 +18,7 @@
 #include <mutex> // NOLINT
 #include <memory>
 #include <vector>
-#include <SpriteObject.hpp>
+#include <GameObject2D.hpp>
 #include <UiObject.hpp>
 #include <TextObject.hpp>
 
@@ -84,7 +84,7 @@ struct TrackConfiguration {
  * @brief Contains a set of tracks for a target object.
  */
 struct TrackStoreEntry {
-    SpriteObject *target;
+    GameObject2D *target;
     std::shared_ptr<TrackConfiguration> track;
 };
 
@@ -99,8 +99,8 @@ struct ActiveTrackEntry {
     float sequenceTime;
     float currentTime = 0.0f;
     int currentTrackIdx;
-    SpriteObject *target;
-    inline ActiveTrackEntry(std::shared_ptr<TrackConfiguration> tr, float sPF, float sT, int cTI, SpriteObject *ta) :
+    GameObject2D *target;
+    inline ActiveTrackEntry(std::shared_ptr<TrackConfiguration> tr, float sPF, float sT, int cTI, GameObject2D *ta) :
         track { tr }, secondsPerFrame { sPF }, sequenceTime { sT }, currentTrackIdx { cTI }, target { ta } {};
 };
 
@@ -126,7 +126,7 @@ struct KeyFrames {
 class AnimationController {
  public:
     int addKeyFrame(SceneObject *target, std::shared_ptr<KeyFrame> keyFrame);
-    void addTrack(SpriteObject *target, string trackName, vector<int> trackData, int fps, bool loop);
+    void addTrack(GameObject2D *target, string trackName, vector<int> trackData, int fps, bool loop);
     void update();
     int updatePosition(SceneObject *target, KeyFrame *keyFrame);
     int updateRotation(SceneObject *target, KeyFrame *keyFrame);

--- a/src/main/engine/AnimationController/src/AnimationController.cpp
+++ b/src/main/engine/AnimationController/src/AnimationController.cpp
@@ -35,17 +35,17 @@ std::shared_ptr<KeyFrame> AnimationController::createKeyFrame(int type, float ti
 /**
  * @brief Creates and adds a track configuration to the internal track store. Adding a track to the
  * track store will not automatically play it. @see AnimationController::playTrack.
- * @param target The SpriteObject to apply the animation track to.
+ * @param target The GameObject2D to apply the animation track to.
  * @param trackName Friendly name of the animation track.
- * @param trackData The actual track data. Each number in the list corresponds to a frame to set in the SpriteObject's
+ * @param trackData The actual track data. Each number in the list corresponds to a frame to set in the GameObject2D's
  * sprite grid. For example, the trackData { 3, 4, 5 } means that the animation track will first display frame 3, then
  * 4 and then 5. The speed at which frames are sequentially switched is determined by the supplied fps rate. An empty
  * vector for trackData is actually legal, and will default to a set of increasing numbers starting from 0 to the
- * number of available frames in the SpriteObject. For a SpriteObject with 4 frames, the default trackData would look
+ * number of available frames in the GameObject2D. For a GameObject2D with 4 frames, the default trackData would look
  * like { 0, 1, 2, 3 }.
  * @param fps The framerate the animation should play back.
  * @param loop Will control whether the animation loops infinitely or ends on last frame.
- * @note There is no trackData bounds checking at this level. Bounds checking occurs at the SpriteObject level.
+ * @note There is no trackData bounds checking at this level. Bounds checking occurs at the GameObject2D level.
  * 
  * There are two internal AnimationController maps that are used to store and play track data.
  * trackStore_ -> Internal map of tracks.
@@ -55,7 +55,7 @@ std::shared_ptr<KeyFrame> AnimationController::createKeyFrame(int type, float ti
  * will be stopped and replaced with the new track. Memory is managed through smart pointers, so everything should
  * clean up on its own.
  */
-void AnimationController::addTrack(SpriteObject *target, string trackName, vector<int> trackData, int fps, bool loop) {
+void AnimationController::addTrack(GameObject2D *target, string trackName, vector<int> trackData, int fps, bool loop) {
     std::unique_lock<std::mutex> scopeLock(controllerLock_);
     if (target == nullptr) {
         fprintf(stderr, "AnimationController::addTrack: target cannot be null.\n");
@@ -459,7 +459,7 @@ int AnimationController::updateTime(SceneObject *target, KeyFrame *keyFrame) {
 }
 
 /**
- * @brief Updates the currently rendered frame of the target SpriteObject based on framerate of animation track,
+ * @brief Updates the currently rendered frame of the target GameObject2D based on framerate of animation track,
  * deltaTime, and data from the track.
  * @param trackPlayback The active track to update.
  * @return true if the track is complete, false if it's still ongoing.

--- a/src/main/engine/AnimationController/src/AnimationController.cpp
+++ b/src/main/engine/AnimationController/src/AnimationController.cpp
@@ -4,9 +4,9 @@
  * @brief Implementation for Animation Controller
  * @version 0.1
  * @date 2024-10-20
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 
 #include <vector>
@@ -46,7 +46,7 @@ std::shared_ptr<KeyFrame> AnimationController::createKeyFrame(int type, float ti
  * @param fps The framerate the animation should play back.
  * @param loop Will control whether the animation loops infinitely or ends on last frame.
  * @note There is no trackData bounds checking at this level. Bounds checking occurs at the TrackExt level.
- * 
+ *
  * There are two internal AnimationController maps that are used to store and play track data.
  * trackStore_ -> Internal map of tracks.
  * activeTracks_ -> This is a map of object names to ActiveTrackEntry. An ActiveTrackEntry is just playback information
@@ -501,7 +501,7 @@ void AnimationController::removeSceneObject(string objectName) {
         if (entry.second.target->getObj()->getObjectName().compare(objectName) == 0) {
             toDelete.push_back(entry.first);
         }
-    };
+    }
     for (auto entry : toDelete) {
         auto tsit = trackStore_.find(entry);
         trackStore_.erase(tsit);
@@ -511,4 +511,3 @@ void AnimationController::removeSceneObject(string objectName) {
     if (kfit != keyFrameStore_.end())
         keyFrameStore_.erase(kfit);
 }
-

--- a/src/main/engine/AnimationController/src/AnimationController.cpp
+++ b/src/main/engine/AnimationController/src/AnimationController.cpp
@@ -492,7 +492,8 @@ void AnimationController::removeSceneObject(string objectName) {
     std::unique_lock<std::mutex> scopeLock(controllerLock_);
     // Delete active tracks
     auto atit = activeTracks_.find(objectName);
-    activeTracks_.erase(atit);
+    if (atit != activeTracks_.end())
+        activeTracks_.erase(atit);
 
     // Delete track stores
     vector<string> toDelete;
@@ -507,6 +508,7 @@ void AnimationController::removeSceneObject(string objectName) {
     }
     // delete keyframes
     auto kfit = keyFrameStore_.find(objectName);
-    keyFrameStore_.erase(kfit);
+    if (kfit != keyFrameStore_.end())
+        keyFrameStore_.erase(kfit);
 }
 

--- a/src/main/engine/AnimationController/test/src/AnimationControllerTests.cpp
+++ b/src/main/engine/AnimationController/test/src/AnimationControllerTests.cpp
@@ -29,10 +29,10 @@ const int INDEX_SHIFT = 1;
 const char *testSpritePath = "../src/resources/images/test_image.png";
 /**
  * @brief Launches google test suite defined in file
- * 
- * @param argc 
- * @param argv 
- * @return int 
+ *
+ * @param argc
+ * @param argv
+ * @return int
  */
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
@@ -72,7 +72,7 @@ class GivenAnAnimationController {
 /**
  * @brief Initializes mocks for the GfxController. Most mocks just define default behavior, but
  * the EXPECT_CALL mocks will capture generated frame data from the SpriteObject.
- * 
+ *
  */
 void GivenAnAnimationController::initMocks() {
     // Set up the mock GfxController
@@ -138,7 +138,7 @@ void GivenAnAnimationController::SetUp() {
         ObjectAnchor::TOP_LEFT, &mockGfxController_);
 
     /* Call split grid on the sprite object */
-    spriteObject_->splitGrid(width, height, numFrames);
+    spriteObject_->createAnimation(width, height, numFrames);
 }
 
 void GivenAnAnimationController::TearDown() {
@@ -316,4 +316,3 @@ TEST_F(GivenAnAnimationControllerToTestRunning, WhenPausedInMiddleOfPlayback_The
     /* Validation - Make sure track is where it left off */
     validateActiveTracks(1, TrackState::RUNNING, INDEX_SHIFT * framesPassed);
 }
-

--- a/src/main/engine/GfxController/headers/DummyGfxController.hpp
+++ b/src/main/engine/GfxController/headers/DummyGfxController.hpp
@@ -42,6 +42,7 @@ class DummyGfxController : public GfxController {
     GfxResult<unsigned int> enableVertexAttArray(unsigned int layout, size_t size);
     GfxResult<unsigned int> disableVertexAttArray(unsigned int layout);
     GfxResult<unsigned int> drawTriangles(unsigned int size);
+    void setBgColor(float r, float g, float b);
     void deleteVao(unsigned int *vao);
     void deleteBuffer(unsigned int *bufferId);
     void clear(GfxClearMode clearMode);

--- a/src/main/engine/GfxController/headers/GfxController.hpp
+++ b/src/main/engine/GfxController/headers/GfxController.hpp
@@ -111,6 +111,7 @@ class GfxController {
     virtual GfxResult<unsigned int> enableVertexAttArray(unsigned int layout, size_t size) = 0;
     virtual GfxResult<unsigned int> disableVertexAttArray(unsigned int layout) = 0;
     virtual GfxResult<unsigned int> drawTriangles(unsigned int size) = 0;
+    virtual void setBgColor(float r, float g, float b) = 0;
     virtual void clear(GfxClearMode clearMode) = 0;
     virtual void update() = 0;
     virtual void deleteBuffer(unsigned int *bufferId) = 0;

--- a/src/main/engine/GfxController/headers/GfxController.hpp
+++ b/src/main/engine/GfxController/headers/GfxController.hpp
@@ -1,12 +1,12 @@
 /**
  * @file GfxController.hpp
  * @author Christian Galvez
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2024-01-21
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 #pragma once
 #include <string>
@@ -111,6 +111,12 @@ class GfxController {
     virtual GfxResult<unsigned int> enableVertexAttArray(unsigned int layout, size_t size) = 0;
     virtual GfxResult<unsigned int> disableVertexAttArray(unsigned int layout) = 0;
     virtual GfxResult<unsigned int> drawTriangles(unsigned int size) = 0;
+    /**
+     * @brief Sets the background color of the window.
+     * @param r Red value from 0.0f to 1.0f.
+     * @param g Green value from 0.0f to 1.0f.
+     * @param b Blue value from 0.0f to 1.0f.
+     */
     virtual void setBgColor(float r, float g, float b) = 0;
     virtual void clear(GfxClearMode clearMode) = 0;
     virtual void update() = 0;

--- a/src/main/engine/GfxController/headers/MockGfxController.hpp
+++ b/src/main/engine/GfxController/headers/MockGfxController.hpp
@@ -4,9 +4,9 @@
  * @brief Mock GfxController implemenation for unit tests.
  * @version 0.1
  * @date 2023-07-28
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 #pragma once
 #include <gmock/gmock.h>
@@ -46,4 +46,6 @@ class MockGfxController : public GfxController {
     MOCK_METHOD(void, update, (), (override));
     MOCK_METHOD(void, deleteBuffer, (unsigned int *), (override));
     MOCK_METHOD(void, deleteVao, (unsigned int *), (override));
+    // virtual void setBgColor(float r, float g, float b) = 0;
+    MOCK_METHOD(void, setBgColor, (float r, float g, float b), (override));
 };

--- a/src/main/engine/GfxController/headers/OpenGlEsGfxController.hpp
+++ b/src/main/engine/GfxController/headers/OpenGlEsGfxController.hpp
@@ -56,6 +56,7 @@ class OpenGlEsGfxController : public GfxController {
     GfxResult<unsigned int> enableVertexAttArray(unsigned int layout, size_t size);
     GfxResult<unsigned int> disableVertexAttArray(unsigned int layout);
     GfxResult<unsigned int> drawTriangles(unsigned int size);
+    void setBgColor(float r, float g, float b);
     void deleteVao(unsigned int *vao);
     void deleteBuffer(unsigned int *bufferId);
     void clear(GfxClearMode clearMode);
@@ -65,6 +66,7 @@ class OpenGlEsGfxController : public GfxController {
 
  private:
     vector<unsigned int> programIdList_;
+    vector<float> bgColor_;
     // VAO -> (VBO -> Attribute Data)
     map<unsigned int, map<unsigned int, GfxVaoData>> vaoBindData_;
     unsigned int activeVao_ = 0;

--- a/src/main/engine/GfxController/headers/OpenGlGfxController.hpp
+++ b/src/main/engine/GfxController/headers/OpenGlGfxController.hpp
@@ -50,6 +50,7 @@ class OpenGlGfxController : public GfxController {
     GfxResult<unsigned int> enableVertexAttArray(unsigned int layout, size_t size);
     GfxResult<unsigned int> disableVertexAttArray(unsigned int layout);
     GfxResult<unsigned int> drawTriangles(unsigned int size);
+    void setBgColor(float r, float g, float b);
     void deleteVao(unsigned int *vao);
     void deleteBuffer(unsigned int *bufferId);
     void clear(GfxClearMode clearMode);
@@ -63,4 +64,5 @@ class OpenGlGfxController : public GfxController {
     vector<unsigned int> vaoList_;
     vector<unsigned int> vboList_;
     vector<unsigned int> textureIdList_;
+    vector<float> bgColor_;
 };

--- a/src/main/engine/GfxController/src/DummyGfxController.cpp
+++ b/src/main/engine/GfxController/src/DummyGfxController.cpp
@@ -182,3 +182,8 @@ void DummyGfxController::deleteVao(unsigned int *vao) {
         vao);
 }
 
+void DummyGfxController::setBgColor(float r, float g, float b) {
+    printf("GfxController::setBgColor: %f, %f, %f\n",
+        r, g, b);
+}
+

--- a/src/main/engine/GfxController/src/OpenGlEsGfxController.cpp
+++ b/src/main/engine/GfxController/src/OpenGlEsGfxController.cpp
@@ -727,3 +727,6 @@ void OpenGlEsGfxController::deleteVao(unsigned int *vao) {
     *vao = UINT_MAX;
 }
 
+void OpenGlEsGfxController::setBgColor(float r, float g, float b) {
+    bgColor_ = { r , g, b };
+}

--- a/src/main/engine/GfxController/src/OpenGlEsGfxController.cpp
+++ b/src/main/engine/GfxController/src/OpenGlEsGfxController.cpp
@@ -1,12 +1,12 @@
 /**
  * @file OpenGlEsGfxController.cpp
  * @author Christian Galvez
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2024-01-21
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 #include <string>
 #include <iostream>
@@ -18,7 +18,7 @@
 
 /**
  * @brief Generates a buffer in the OpenGL context
- * 
+ *
  * @param bufferId unsigned int to store new buffer ID created in OpenGL context
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
  */
@@ -37,7 +37,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::generateBuffer(unsigned int *buff
 
 /**
  * @brief Binds a buffer to the current OpenGL context
- * 
+ *
  * @param bufferId ID of buffer to bind (needs to be generated first via generateBuffer)
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
  */
@@ -60,7 +60,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::bindBuffer(unsigned int bufferId)
 /**
  * @brief Sends data to the currently bound buffer in the OpenGL context. This transfers data from the application
  * side (c++ studious) to the GPU side (OpenGL in this case).
- * 
+ *
  * @param size Size of the data array
  * @param data The data array write to the OpenGL buffer
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
@@ -91,7 +91,7 @@ std::shared_ptr<uint8_t[]> OpenGlEsGfxController::convertToRgba(size_t size, uin
 
 /**
  * @brief Copies texture data to the currently bound texture buffer.
- * 
+ *
  * @param width of the texture to send
  * @param height of the texture to send
  * @param format of the texture
@@ -133,7 +133,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::sendTextureData(unsigned int widt
 
 /**
  * @brief Generates mipmaps for the currently bound texture
- * 
+ *
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
  */
 GfxResult<unsigned int> OpenGlEsGfxController::generateMipMap() {
@@ -145,7 +145,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::generateMipMap() {
 
 /**
  * @brief Generates a new texture and writes the new texture ID to the textureId variable passed in.
- * 
+ *
  * @param textureId assigned to newly created texture in OpenGL context.
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
  */
@@ -162,7 +162,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::generateTexture(unsigned int *tex
 
 /**
  * @brief Gets a programId for a specific index in the programIdList.
- * 
+ *
  * @param index in the programId list
  * @return GfxResult<unsigned int> OK with returned program ID when successful; FAILURE otherwise.
  */
@@ -176,7 +176,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::getProgramId(uint index) {
 
 /**
  * @brief Compiles shaders and adds them to the programId list for this GfxController.
- * 
+ *
  * @param vertexShader Path to the vertexShader to compile on the system
  * @param fragmentShader Path to the fragmentShader to compile on the system
  * @return GfxResult<unsigned int> OK with the newly created programId; FAILURE otherwise.
@@ -259,7 +259,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::loadShaders(string vertexShader, 
 
 /**
  * @brief Gets the location of a variable in a shader
- * 
+ *
  * @param programId program to search for variable inside of.
  * @param variableName name of variable to find in shader.
  * @return GfxResult<int> OK with variableId; FAILURE otherwise.
@@ -274,7 +274,7 @@ GfxResult<int> OpenGlEsGfxController::getShaderVariable(unsigned int programId, 
 /**
  * @brief Has a list of OpenGL specific commands that update once per frame. This is not part of the GfxController
  * interface.
- * 
+ *
  */
 void OpenGlEsGfxController::updateOpenGl() {
     glEnable(GL_DEPTH_TEST);
@@ -294,7 +294,7 @@ void OpenGlEsGfxController::updateOpenGl() {
 
 /**
  * @brief Runs through any updates.
- * 
+ *
  */
 void OpenGlEsGfxController::update() {
     updateOpenGl();
@@ -302,7 +302,7 @@ void OpenGlEsGfxController::update() {
 
 /**
  * @brief Initialize the OpenGL context.
- * 
+ *
  * @return GfxResult<int> OK if successful; FAILURE otherwise
  */
 GfxResult<int> OpenGlEsGfxController::init() {
@@ -318,7 +318,7 @@ GfxResult<int> OpenGlEsGfxController::init() {
 
 /**
  * @brief Sets the current program (shader) in the OpenGL context.
- * 
+ *
  * @param programId created by OpenGL for a set of shaders (program).
  * @return GfxResult<unsigned int> OK if successful, FAILURE if error occurred
  */
@@ -334,7 +334,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::setProgram(unsigned int programId
 
 /**
  * @brief Sends a float to a corresponding variable inside of a program (shader)
- * 
+ *
  * @param variableId of the variable inside of the program to send data to
  * @param data to write to variable
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
@@ -346,7 +346,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::sendFloat(unsigned int variableId
 
 /**
  * @brief Sends a 3D vector of floats to a shader variable
- * 
+ *
  * @param variableId variableId to write data to
  * @param count Number of float vectors to send
  * @param data Raw data to send to GPU
@@ -360,7 +360,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::sendFloatVector(unsigned int vari
 /**
  * @brief Sets the rendering mode for triangles.
  * @see RenderMode enum for rendering options.
- * 
+ *
  * @param mode method for rendering triangles.
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
  */
@@ -376,7 +376,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::polygonRenderMode(RenderMode mode
 
 /**
  * @brief Sends a 4x4 matrix of floats to the GPU memory for a variable in the current program.
- * 
+ *
  * @param variableId Variable to write data to
  * @param count Number of matrices to write - generally just one
  * @param data Raw data to send over to program variable.
@@ -389,7 +389,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::sendFloatMatrix(unsigned int vari
 
 /**
  * @brief Sends an integer to the GPU memory for a variable in the current program.
- * 
+ *
  * @param variableId Variable identifier in the current program
  * @param data Raw data to copy to GPU
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
@@ -401,7 +401,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::sendInteger(unsigned int variable
 
 /**
  * @brief Binds a texture to the current OpenGL context.
- * 
+ *
  * @param textureId ID of texture to bind.
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
  */
@@ -422,7 +422,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::bindTexture(unsigned int textureI
 /**
  * @brief Binds a VAO object in the current OpenGL context
  * @note The name of this method will most likely change other GFX backends are added.
- * 
+ *
  * @param vao VAO ID to bind
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
  */
@@ -479,11 +479,11 @@ GfxResult<unsigned int> OpenGlEsGfxController::bindVao(unsigned int vao) {
 
 /**
  * @brief Enables/Disables an OpenGL capability in the current context.
- * 
+ *
  *        Usage: setFeature(GL_CULL_FACE, true)
- * 
+ *
  * will enable the GL_CULL_FACE capability.
- * 
+ *
  * @param capabilityId ID of the capability to toggle on/off.
  * @param enabled Whether or not to enable/disable the capability
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
@@ -510,7 +510,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::setCapability(GfxCapability capab
 
 /**
  * @brief Initializes a VAO object
- * 
+ *
  * @param vao to initialize
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
  */
@@ -529,7 +529,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::initVao(unsigned int *vao) {
 
 /**
  * @brief Deletes textures from the OpenGL context.
- * 
+ *
  * @param tId texture ID to delete in the OpenGL context.
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
  */
@@ -545,7 +545,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::deleteTextures(unsigned int *tId)
 
 /**
  * @brief Updates a VBO buffer with a set of vertices
- * 
+ *
  * @param vertices Vector of vertex data to copy to VBO object
  * @param vbo identifier for the buffer to write data into
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
@@ -564,7 +564,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::updateBufferData(const vector<flo
 
 /**
  * @brief Sets a texture parameter for the texture currently bound in the OpenGL context
- * 
+ *
  * @param param parameter to update @see TexParam in GfxController
  * @param val value to set for the given parameter
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
@@ -624,7 +624,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::setTexParam(TexParam param, TexVa
 
 /**
  * @brief Enables a vertex attribute array and configures the vertex attribute pointer
- * 
+ *
  * @param layout The layout set in the OpenGL shader
  * @param size The per-object size. A 3D vertex would have a size of 3, because each point is made of 3 floats
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
@@ -648,7 +648,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::enableVertexAttArray(unsigned int
 
 /**
  * @brief Disables a vertex attribute array in the OpenGL context.
- * 
+ *
  * @param layout The layout of the vertex attribute array to disable in the current program.
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
  */
@@ -664,7 +664,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::disableVertexAttArray(unsigned in
 
 /**
  * @brief Draws triangles using currently bound textures/buffers.
- * 
+ *
  * @param size The number of vertices to render
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
  */
@@ -682,7 +682,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::drawTriangles(unsigned int size) 
 /**
  * @brief Clears buffers in the OpenGL context. Common uses are COLOR buffers (framebuffer) or
  * DEPTH buffers.
- * 
+ *
  * @param clearMode what should be cleared @see GfxClearMode
  */
 void OpenGlEsGfxController::clear(GfxClearMode clearMode) {
@@ -704,7 +704,7 @@ void OpenGlEsGfxController::clear(GfxClearMode clearMode) {
 
 /**
  * @brief Deletes a VBO object
- * 
+ *
  * @param bufferId pointer to VBO ID of buffer to delete
  */
 void OpenGlEsGfxController::deleteBuffer(unsigned int *bufferId) {
@@ -717,7 +717,7 @@ void OpenGlEsGfxController::deleteBuffer(unsigned int *bufferId) {
 
 /**
  * @brief Deletes a VAO object
- * 
+ *
  * @param vao pointer to VAO ID of VAO to delete
  */
 void OpenGlEsGfxController::deleteVao(unsigned int *vao) {

--- a/src/main/engine/GfxController/src/OpenGlGfxController.cpp
+++ b/src/main/engine/GfxController/src/OpenGlGfxController.cpp
@@ -1,12 +1,12 @@
 /**
  * @file OpenGlGfxController.cpp
  * @author Christian Galvez
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2024-01-21
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 #include <string>
 #include <iostream>
@@ -17,7 +17,7 @@
 
 /**
  * @brief Generates a buffer in the OpenGL context
- * 
+ *
  * @param bufferId unsigned int to store new buffer ID created in OpenGL context
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
  */
@@ -37,7 +37,7 @@ GfxResult<unsigned int> OpenGlGfxController::generateBuffer(unsigned int *buffer
 
 /**
  * @brief Binds a buffer to the current OpenGL context
- * 
+ *
  * @param bufferId ID of buffer to bind (needs to be generated first via generateBuffer)
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
  */
@@ -54,7 +54,7 @@ GfxResult<unsigned int> OpenGlGfxController::bindBuffer(unsigned int bufferId) {
 /**
  * @brief Sends data to the currently bound buffer in the OpenGL context. This transfers data from the application
  * side (c++ studious) to the GPU side (OpenGL in this case).
- * 
+ *
  * @param size Size of the data array
  * @param data The data array write to the OpenGL buffer
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
@@ -74,7 +74,7 @@ GfxResult<unsigned int> OpenGlGfxController::sendBufferData(size_t size, void *d
 
 /**
  * @brief Copies texture data to the currently bound texture buffer.
- * 
+ *
  * @param width of the texture to send
  * @param height of the texture to send
  * @param format of the texture
@@ -110,7 +110,7 @@ GfxResult<unsigned int> OpenGlGfxController::sendTextureData(unsigned int width,
 
 /**
  * @brief Generates mipmaps for the currently bound texture
- * 
+ *
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
  */
 GfxResult<unsigned int> OpenGlGfxController::generateMipMap() {
@@ -125,7 +125,7 @@ GfxResult<unsigned int> OpenGlGfxController::generateMipMap() {
 
 /**
  * @brief Generates a new texture and writes the new texture ID to the textureId variable passed in.
- * 
+ *
  * @param textureId assigned to newly created texture in OpenGL context.
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
  */
@@ -143,7 +143,7 @@ GfxResult<unsigned int> OpenGlGfxController::generateTexture(unsigned int *textu
 
 /**
  * @brief Gets a programId for a specific index in the programIdList.
- * 
+ *
  * @param index in the programId list
  * @return GfxResult<unsigned int> OK with returned program ID when successful; FAILURE otherwise.
  */
@@ -157,7 +157,7 @@ GfxResult<unsigned int> OpenGlGfxController::getProgramId(uint index) {
 
 /**
  * @brief Compiles shaders and adds them to the programId list for this GfxController.
- * 
+ *
  * @param vertexShader Path to the vertexShader to compile on the system
  * @param fragmentShader Path to the fragmentShader to compile on the system
  * @return GfxResult<unsigned int> OK with the newly created programId; FAILURE otherwise.
@@ -237,7 +237,7 @@ GfxResult<unsigned int> OpenGlGfxController::loadShaders(string vertexShader, st
 
 /**
  * @brief Gets the location of a variable in a shader
- * 
+ *
  * @param programId program to search for variable inside of.
  * @param variableName name of variable to find in shader.
  * @return GfxResult<int> OK with variableId; FAILURE otherwise.
@@ -252,7 +252,7 @@ GfxResult<int> OpenGlGfxController::getShaderVariable(unsigned int programId, co
 /**
  * @brief Has a list of OpenGL specific commands that update once per frame. This is not part of the GfxController
  * interface.
- * 
+ *
  */
 void OpenGlGfxController::updateOpenGl() {
     glEnable(GL_MULTISAMPLE);
@@ -273,7 +273,7 @@ void OpenGlGfxController::updateOpenGl() {
 
 /**
  * @brief Runs through any updates.
- * 
+ *
  */
 void OpenGlGfxController::update() {
     updateOpenGl();
@@ -281,7 +281,7 @@ void OpenGlGfxController::update() {
 
 /**
  * @brief Initialize the OpenGL context.
- * 
+ *
  * @return GfxResult<int> OK if successful; FAILURE otherwise
  */
 GfxResult<int> OpenGlGfxController::init() {
@@ -297,7 +297,7 @@ GfxResult<int> OpenGlGfxController::init() {
 
 /**
  * @brief Sets the current program (shader) in the OpenGL context.
- * 
+ *
  * @param programId created by OpenGL for a set of shaders (program).
  * @return GfxResult<unsigned int> OK if successful, FAILURE if error occurred
  */
@@ -313,7 +313,7 @@ GfxResult<unsigned int> OpenGlGfxController::setProgram(unsigned int programId) 
 
 /**
  * @brief Sends a float to a corresponding variable inside of a program (shader)
- * 
+ *
  * @param variableId of the variable inside of the program to send data to
  * @param data to write to variable
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
@@ -325,7 +325,7 @@ GfxResult<unsigned int> OpenGlGfxController::sendFloat(unsigned int variableId, 
 
 /**
  * @brief Sends a 3D vector of floats to a shader variable
- * 
+ *
  * @param variableId variableId to write data to
  * @param count Number of float vectors to send
  * @param data Raw data to send to GPU
@@ -339,7 +339,7 @@ GfxResult<unsigned int> OpenGlGfxController::sendFloatVector(unsigned int variab
 /**
  * @brief Sets the rendering mode for triangles.
  * @see RenderMode enum for rendering options.
- * 
+ *
  * @param mode method for rendering triangles.
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
  */
@@ -373,7 +373,7 @@ GfxResult<unsigned int> OpenGlGfxController::polygonRenderMode(RenderMode mode) 
 
 /**
  * @brief Sends a 4x4 matrix of floats to the GPU memory for a variable in the current program.
- * 
+ *
  * @param variableId Variable to write data to
  * @param count Number of matrices to write - generally just one
  * @param data Raw data to send over to program variable.
@@ -386,7 +386,7 @@ GfxResult<unsigned int> OpenGlGfxController::sendFloatMatrix(unsigned int variab
 
 /**
  * @brief Sends an integer to the GPU memory for a variable in the current program.
- * 
+ *
  * @param variableId Variable identifier in the current program
  * @param data Raw data to copy to GPU
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
@@ -398,7 +398,7 @@ GfxResult<unsigned int> OpenGlGfxController::sendInteger(unsigned int variableId
 
 /**
  * @brief Binds a texture to the current OpenGL context.
- * 
+ *
  * @param textureId ID of texture to bind.
  * @return GfxResult<unsigned int> OK if successful; FAILURE otherwise
  */
@@ -419,7 +419,7 @@ GfxResult<unsigned int> OpenGlGfxController::bindTexture(unsigned int textureId)
 /**
  * @brief Binds a VAO object in the current OpenGL context
  * @note The name of this method will most likely change other GFX backends are added.
- * 
+ *
  * @param vao VAO ID to bind
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
  */
@@ -436,11 +436,11 @@ GfxResult<unsigned int> OpenGlGfxController::bindVao(unsigned int vao) {
 
 /**
  * @brief Enables/Disables an OpenGL capability in the current context.
- * 
+ *
  *        Usage: setFeature(GL_CULL_FACE, true)
- * 
+ *
  * will enable the GL_CULL_FACE capability.
- * 
+ *
  * @param capabilityId ID of the capability to toggle on/off.
  * @param enabled Whether or not to enable/disable the capability
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
@@ -467,7 +467,7 @@ GfxResult<unsigned int> OpenGlGfxController::setCapability(GfxCapability capabil
 
 /**
  * @brief Initializes a VAO object
- * 
+ *
  * @param vao to initialize
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
  */
@@ -487,7 +487,7 @@ GfxResult<unsigned int> OpenGlGfxController::initVao(unsigned int *vao) {
 
 /**
  * @brief Deletes textures from the OpenGL context.
- * 
+ *
  * @param tId texture ID to delete in the OpenGL context.
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
  */
@@ -504,7 +504,7 @@ GfxResult<unsigned int> OpenGlGfxController::deleteTextures(unsigned int *tId) {
 
 /**
  * @brief Updates a VBO buffer with a set of vertices
- * 
+ *
  * @param vertices Vector of vertex data to copy to VBO object
  * @param vbo identifier for the buffer to write data into
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
@@ -523,7 +523,7 @@ GfxResult<unsigned int> OpenGlGfxController::updateBufferData(const vector<float
 
 /**
  * @brief Sets a texture parameter for the texture currently bound in the OpenGL context
- * 
+ *
  * @param param parameter to update @see TexParam in GfxController
  * @param val value to set for the given parameter
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
@@ -585,7 +585,7 @@ GfxResult<unsigned int> OpenGlGfxController::setTexParam(TexParam param, TexVal 
 
 /**
  * @brief Enables a vertex attribute array and configures the vertex attribute pointer
- * 
+ *
  * @param layout The layout set in the OpenGL shader
  * @param size The per-object size. A 3D vertex would have a size of 3, because each point is made of 3 floats
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
@@ -609,7 +609,7 @@ GfxResult<unsigned int> OpenGlGfxController::enableVertexAttArray(unsigned int l
 
 /**
  * @brief Disables a vertex attribute array in the OpenGL context.
- * 
+ *
  * @param layout The layout of the vertex attribute array to disable in the current program.
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
  */
@@ -625,7 +625,7 @@ GfxResult<unsigned int> OpenGlGfxController::disableVertexAttArray(unsigned int 
 
 /**
  * @brief Draws triangles using currently bound textures/buffers.
- * 
+ *
  * @param size The number of vertices to render
  * @return GfxResult<unsigned int> OK if succeeded, FAILURE if error occurred
  */
@@ -642,7 +642,7 @@ GfxResult<unsigned int> OpenGlGfxController::drawTriangles(unsigned int size) {
 /**
  * @brief Clears buffers in the OpenGL context. Common uses are COLOR buffers (framebuffer) or
  * DEPTH buffers.
- * 
+ *
  * @param clearMode what should be cleared @see GfxClearMode
  */
 void OpenGlGfxController::clear(GfxClearMode clearMode) {
@@ -664,7 +664,7 @@ void OpenGlGfxController::clear(GfxClearMode clearMode) {
 
 /**
  * @brief Deletes a VBO object
- * 
+ *
  * @param bufferId pointer to VBO ID of buffer to delete
  */
 void OpenGlGfxController::deleteBuffer(unsigned int *bufferId) {
@@ -680,7 +680,7 @@ void OpenGlGfxController::deleteBuffer(unsigned int *bufferId) {
 
 /**
  * @brief Deletes a VAO object
- * 
+ *
  * @param vao pointer to VAO ID of VAO to delete
  */
 void OpenGlGfxController::deleteVao(unsigned int *vao) {

--- a/src/main/engine/GfxController/src/OpenGlGfxController.cpp
+++ b/src/main/engine/GfxController/src/OpenGlGfxController.cpp
@@ -262,7 +262,7 @@ void OpenGlGfxController::updateOpenGl() {
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glCullFace(GL_BACK);
     glDepthFunc(GL_LESS);
-    glClearColor(0.2f, 0.2f, 0.4f, 1.0f);
+    glClearColor(bgColor_[0], bgColor_[1], bgColor_[2], 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     auto error = glGetError();
     if (error != GL_NO_ERROR) {
@@ -694,7 +694,7 @@ void OpenGlGfxController::deleteVao(unsigned int *vao) {
     }
 }
 
-OpenGlGfxController::OpenGlGfxController() {
+OpenGlGfxController::OpenGlGfxController() : bgColor_ { 0.2f, 0.2f, 0.4f } {
     printf("OpenGlGfxController::OpenGlGfxController\n");
 }
 
@@ -721,4 +721,8 @@ OpenGlGfxController::~OpenGlGfxController() {
     vboList_.clear();
     textureIdList_.clear();
     programIdList_.clear();
+}
+
+void OpenGlGfxController::setBgColor(float r, float g, float b) {
+    bgColor_ = { r, g, b };
 }

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <map>
 #include <atomic>
+#include <queue>
 #include <common.hpp>
 #include <ModelImport.hpp>
 #include <GameObject.hpp>
@@ -24,6 +25,7 @@
 #include <SpriteObject.hpp>
 #include <UiObject.hpp>
 #include <config.hpp>
+#include <AnimationController.hpp>
 
 // Number of samples to use for anti-aliasing
 #define AASAMPLES 8
@@ -51,6 +53,7 @@ class GameInstance {
  private:
     const Uint8 *keystate;
     GfxController *gfxController_;
+    AnimationController *animationController_;
     SDL_Window *window;
     SDL_Renderer *renderer;
     SDL_Event event;
@@ -86,7 +89,7 @@ class GameInstance {
 
  public:
     GameInstance(vector<string> vertShaders,
-        vector<string> fragShaders, GfxController *gfxController, int width, int height);
+        vector<string> fragShaders, GfxController *gfxController, AnimationController *animationController, int width, int height);
     ~GameInstance();
     void startGame(const configData &config);
     GameObject *createGameObject(Polygon *characterModel, vec3 position, vec3 rotation, float scale,
@@ -129,4 +132,5 @@ class GameInstance {
     int unlockScene();
     void shutdown();
     bool waitForKeyDown(SDL_Scancode input);
+    inline int isShutDown() { return shutdown_; }
 };

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -4,9 +4,9 @@
  * @brief GameInstance class contains a current scene to render GameObjects in
  * @version 0.1
  * @date 2023-07-28
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 
 #pragma once
@@ -92,7 +92,8 @@ class GameInstance {
 
  public:
     GameInstance(vector<string> vertShaders,
-        vector<string> fragShaders, GfxController *gfxController, AnimationController *animationController, int width, int height);
+        vector<string> fragShaders, GfxController *gfxController, AnimationController *animationController, int width,
+        int height);
     ~GameInstance();
     void startGame(const configData &config);
     GameObject *createGameObject(Polygon *characterModel, vec3 position, vec3 rotation, float scale,

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -86,6 +86,9 @@ class GameInstance {
     void initController();
     void initApplication(vector<string> vertexPath, vector<string> fragmentPath);
     void runGfxRequests();
+    int updateObjects();
+    int updateWindow();
+    void updateInput();
 
  public:
     GameInstance(vector<string> vertShaders,
@@ -123,10 +126,7 @@ class GameInstance {
     int getCollision2D(GameObject2D *object1, GameObject2D *object2, vec3 moving);
     void setLuminance(float luminanceValue);
     void basicCollision(GameInstance* gameInstance);
-    bool isWindowOpen();
-    int updateObjects();
-    int updateWindow();
-    void updateInput();
+    int update();
     SDL_Scancode getInput();
     int lockScene();
     int unlockScene();

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -17,6 +17,7 @@
 #include <map>
 #include <atomic>
 #include <queue>
+#include <condition_variable>
 #include <common.hpp>
 #include <ModelImport.hpp>
 #include <GameObject.hpp>

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -176,6 +176,14 @@ class GameInstance {
      * @return Returns true if shutdown has been called, false otherwise.
      */
     inline int isShutDown() { return shutdown_; }
+    /**
+     * @brief Blocks caller until the provided predicate is satisfied. Must be signaled manually when
+     * values in the predicate are altered. @see GameInstance::signalProgress().
+     */
     bool waitForProgress(std::function<bool(void)> pred);
+    /**
+     * @brief Signals to the game instance that it should wakeup all threads blocked by
+     * GameInstance::waitForProgress so they can check if their predicate has been satisfied.
+     */
     inline void signalProgress() { progressCv_.notify_all(); }
 };

--- a/src/main/engine/Misc/headers/Image.hpp
+++ b/src/main/engine/Misc/headers/Image.hpp
@@ -9,8 +9,9 @@
  *
  */
 #pragma once
-#include <vector>
 #include <SDL2/SDL_image.h>
+#include <vector>
+#include <memory>
 
 struct Image {
     /* Constraints across all image resolutions */

--- a/src/main/engine/Misc/headers/Image.hpp
+++ b/src/main/engine/Misc/headers/Image.hpp
@@ -4,12 +4,13 @@
  * @brief Image class definition for storing image data
  * @version 0.1
  * @date 2024-10-20
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 #pragma once
 #include <vector>
+#include <SDL2/SDL_image.h>
 
 struct Image {
     /* Constraints across all image resolutions */
@@ -19,3 +20,5 @@ struct Image {
     /* textureIds for each frame */
     std::vector<unsigned int> textureIds;
 };
+
+std::shared_ptr<uint8_t[]> packSurface(SDL_Surface *texture);

--- a/src/main/engine/Misc/headers/Image.hpp
+++ b/src/main/engine/Misc/headers/Image.hpp
@@ -22,4 +22,10 @@ struct Image {
     std::vector<unsigned int> textureIds;
 };
 
+/**
+ * @brief Tightly packs texture data stored in an SDL_Surface to remove 4-byte alignment.
+ *
+ * @param texture Valid SDL_Surface containing image data.
+ * @return std::shared_ptr<uint8_t[]> Buffer containing tightly packed pixel data.
+ */
 std::shared_ptr<uint8_t[]> packSurface(SDL_Surface *texture);

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -4,9 +4,9 @@
  * @brief Implementation of gameInstance
  * @version 0.1
  * @date 2023-07-28
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 #include <cstdio>
 #include <iostream>
@@ -31,7 +31,8 @@
 GameInstance::GameInstance(vector<string> vertShaders,
         vector<string> fragShaders, GfxController *gfxController, AnimationController *animationController,
         int width, int height) : gfxController_ { gfxController }, animationController_ { animationController },
-        vertShaders_ { vertShaders }, fragShaders_ { fragShaders }, width_ { width }, height_ { height }, shutdown_ ( 0 ) {
+        vertShaders_ { vertShaders }, fragShaders_ { fragShaders }, width_ { width }, height_ { height },
+        shutdown_(0) {
     luminance = 1.0f;  // Set default values
     directionalLight = vec3(-100, 100, 100);
     controllersConnected = 0;

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -217,9 +217,9 @@ bool GameInstance::isWindowOpen() {
     bool running = true;
     while (SDL_PollEvent(&event)) {
         if (event.type == SDL_QUIT || keystate[SDL_SCANCODE_ESCAPE]) {
-            cout << "Closing now...\n";
-            running = false;
-        }
+        cout << "Closing now...\n";
+        running = false;
+    }
     }
     return running;
 }

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -28,9 +28,9 @@
  (void) startGameInstance does not return any value.
  */
 GameInstance::GameInstance(vector<string> vertShaders,
-        vector<string> fragShaders, GfxController *gfxController, int width, int height)
-        : gfxController_ { gfxController }, vertShaders_ { vertShaders },
-        fragShaders_ { fragShaders }, width_ { width }, height_ { height }, shutdown_ ( 0 ) {
+        vector<string> fragShaders, GfxController *gfxController, AnimationController *animationController,
+        int width, int height) : gfxController_ { gfxController }, animationController_ { animationController },
+        vertShaders_ { vertShaders }, fragShaders_ { fragShaders }, width_ { width }, height_ { height }, shutdown_ ( 0 ) {
     luminance = 1.0f;  // Set default values
     directionalLight = vec3(-100, 100, 100);
     controllersConnected = 0;
@@ -411,6 +411,7 @@ SceneObject *GameInstance::getSceneObject(string objectName) {
 
 int GameInstance::removeSceneObject(string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
+    animationController_->removeSceneObject(objectName);
     // Search for the object by name
     auto objectIt = std::find_if(sceneObjects_.begin(), sceneObjects_.end(),
         [&objectName](std::shared_ptr<SceneObject> obj) {

--- a/src/main/engine/Misc/src/Image.cpp
+++ b/src/main/engine/Misc/src/Image.cpp
@@ -1,5 +1,12 @@
+/**
+ * @file Image.cpp
+ * @brief Helper functions for managing texture data.
+ * @author Christian Galvez
+ * @date May 9, 2025
+ * @copyright Studious-Engine 2025
+ */
 #include <Image.hpp>
-
+#include <memory>
 /**
  * @brief Tightly packs texture data stored in an SDL_Surface to remove 4-byte alignment.
  *

--- a/src/main/engine/Misc/src/Image.cpp
+++ b/src/main/engine/Misc/src/Image.cpp
@@ -1,0 +1,20 @@
+#include <Image.hpp>
+
+/**
+ * @brief Tightly packs texture data stored in an SDL_Surface to remove 4-byte alignment.
+ *
+ * @param texture Valid SDL_Surface containing image data.
+ * @return std::shared_ptr<uint8_t[]> Buffer containing tightly packed pixel data.
+ */
+std::shared_ptr<uint8_t[]> packSurface(SDL_Surface *texture) {
+    /* Tightly pack to remove 4 byte alignment on texture */
+    auto pixelSize = texture->format->BytesPerPixel;
+    std::shared_ptr<uint8_t[]> packedData(new uint8_t[texture->w * texture->h * pixelSize],
+        std::default_delete<uint8_t[]>());
+    for (int i = 0; i < texture->h; ++i) {
+        memcpy(&packedData.get()[i * pixelSize * texture->w],
+            &(reinterpret_cast<uint8_t *>(texture->pixels))[i * (texture->pitch)],
+            pixelSize * texture->w);
+    }
+    return packedData;
+}

--- a/src/main/engine/Misc/src/Image.cpp
+++ b/src/main/engine/Misc/src/Image.cpp
@@ -7,12 +7,7 @@
  */
 #include <Image.hpp>
 #include <memory>
-/**
- * @brief Tightly packs texture data stored in an SDL_Surface to remove 4-byte alignment.
- *
- * @param texture Valid SDL_Surface containing image data.
- * @return std::shared_ptr<uint8_t[]> Buffer containing tightly packed pixel data.
- */
+
 std::shared_ptr<uint8_t[]> packSurface(SDL_Surface *texture) {
     /* Tightly pack to remove 4 byte alignment on texture */
     auto pixelSize = texture->format->BytesPerPixel;

--- a/src/main/engine/SceneObject/headers/CameraObject.hpp
+++ b/src/main/engine/SceneObject/headers/CameraObject.hpp
@@ -26,6 +26,7 @@ class CameraObject : public SceneObject {
     // Setters
     inline void setOffset(vec3 offset) { offset_ = offset; }
     inline void setAspectRatio(float aspectRatio) { aspectRatio_ = aspectRatio; }
+    inline void setTarget(SceneObject *target) { target_ = target; }
 
     // Getters
     inline vec3 getOffset() { return offset_; }
@@ -38,6 +39,7 @@ class CameraObject : public SceneObject {
     void update() override;
     void addSceneObject(SceneObject *gameObject);
     void removeSceneObject(string objectName);
+    inline void clearSceneObjects() { sceneObjects_.clear(); }
 
  private:
     SceneObject *target_;

--- a/src/main/engine/SceneObject/headers/GameObject.hpp
+++ b/src/main/engine/SceneObject/headers/GameObject.hpp
@@ -27,13 +27,11 @@ class GameObject: public SceneObject {
     ~GameObject() override;
 
     // Setters
-    inline void setScale(float scale) { this->scale = scale; }
     inline void setDirectionalLight(vec3 directionalLight) { this->directionalLight = directionalLight; }
     inline void setLuminance(float luminance) { this->luminance = luminance; }
     inline void setProgramId(unsigned int programId) { this->programId_ = programId; }
 
     // Getters
-    inline float getScale() { return this->scale; }
     inline vec3 getDirectionalLight() { return this->directionalLight; }
     inline float getLuminance() { return this->luminance; }
     inline unsigned int getProgramId() { return this->programId_; }

--- a/src/main/engine/SceneObject/headers/GameObject2D.hpp
+++ b/src/main/engine/SceneObject/headers/GameObject2D.hpp
@@ -4,9 +4,9 @@
  * @brief SpriteObject is a SceneObject; can be rendered by a CameraObject
  * @version 0.1
  * @date 2023-07-28
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 
 #pragma once
@@ -36,6 +36,7 @@ class GameObject2D : public SceneObject, public TrackExt {
     void initializeVertexData();
     void createCollider(int programId);
     void setDimensions(int width, int height);
+
  protected:
     string texturePath_;
     std::shared_ptr<ColliderObject> collider_;

--- a/src/main/engine/SceneObject/headers/GameObject2D.hpp
+++ b/src/main/engine/SceneObject/headers/GameObject2D.hpp
@@ -36,10 +36,6 @@ class GameObject2D : public SceneObject, public TrackExt {
     void initializeVertexData();
     void createCollider(int programId);
     void setDimensions(int width, int height);
-
-    // Animation Methods
-    virtual void createAnimation(int width, int height, int frameCount) = 0;
-
  protected:
     string texturePath_;
     std::shared_ptr<ColliderObject> collider_;

--- a/src/main/engine/SceneObject/headers/GameObject2D.hpp
+++ b/src/main/engine/SceneObject/headers/GameObject2D.hpp
@@ -15,8 +15,9 @@
 #include <memory>
 #include <SceneObject.hpp>
 #include <ColliderObject.hpp>
+#include <TrackExt.hpp>
 
-class GameObject2D : public SceneObject {
+class GameObject2D : public SceneObject, public TrackExt {
  public:
     // Constructors
     /// @todo Remove ObjectType - we render by camera now, so this isn't really needed...
@@ -31,11 +32,13 @@ class GameObject2D : public SceneObject {
     void render() override;
     void update() override;
     void initializeTextureData();
-    void initializeShaderVars();
+    virtual void initializeShaderVars() = 0;
     void initializeVertexData();
     void createCollider(int programId);
-    std::shared_ptr<uint8_t[]> packSurface(SDL_Surface *texture);
     void setDimensions(int width, int height);
+
+    // Animation Methods
+    virtual void createAnimation(int width, int height, int frameCount) = 0;
 
  protected:
     string texturePath_;

--- a/src/main/engine/SceneObject/headers/SceneObject.hpp
+++ b/src/main/engine/SceneObject/headers/SceneObject.hpp
@@ -38,7 +38,7 @@ class SceneObject {
     // Constructors
     inline explicit SceneObject(vec3 position, vec3 rotation, string objectName, float scale, unsigned int programId,
         ObjectType type, GfxController *gfxController):
-            position(position), rotation(rotation), objectName(objectName), scale(scale), programId_(programId),
+            position(position), rotation(rotation), objectName(objectName), scale_(scale), programId_(programId),
             type_ { type }, gfxController_ { gfxController } {}
     inline explicit SceneObject(ObjectType type, string objectName, GfxController *gfxController):
         objectName { objectName }, type_ { type }, gfxController_ { gfxController } {}
@@ -48,7 +48,7 @@ class SceneObject {
     inline void setPosition(vec3 position) { this->position = position; }
     inline void setRotation(vec3 rotation) { this->rotation = rotation; }
     inline void setResolution(vec3 resolution) { this->resolution_ = resolution; }
-    inline void setScale(float scale) { this->scale = scale ; }
+    inline void setScale(float scale) { this->scale_ = scale ; }
     inline void setRenderPriority(RenderPriority renderPriority) { this->renderPriority_ = renderPriority; }
 
     // Getter methods
@@ -59,7 +59,7 @@ class SceneObject {
     inline vec3 getPosition() const { return this->position; }
     inline vec3 getPosition(vec3 offset) const { return this->position + offset; }
     inline vec3 getRotation() const { return this->rotation; }
-    inline float getScale() const { return this->scale; }
+    inline float getScale() const { return this->scale_; }
     inline RenderPriority getRenderPriority() const { return this->renderPriority_; }
     inline vec3 getResolution() const { return this->resolution_; }
     inline string getObjectName() const { return this->objectName; }
@@ -80,7 +80,7 @@ class SceneObject {
     vec3 resolution_;
 
     const string objectName;
-    float scale;
+    float scale_;
     unsigned int programId_;
     unsigned int vao_;
     ObjectType type_;

--- a/src/main/engine/SceneObject/headers/SpriteObject.hpp
+++ b/src/main/engine/SceneObject/headers/SpriteObject.hpp
@@ -14,7 +14,7 @@
 #include <vector>
 #include <GameObject2D.hpp>
 #include <ColliderObject.hpp>
-#include <Image.hpp>
+#include <TrackExt.hpp>
 
 class SpriteObject : public GameObject2D {
  public:
@@ -24,24 +24,20 @@ class SpriteObject : public GameObject2D {
     ~SpriteObject() override;
 
     // Gfx specific functions
-    void initializeShaderVars();
+    void initializeShaderVars() override;
+    void initializeVertexData();
     void render() override;
     void update() override;
 
-    // Animation Specific Functions
-    void splitGrid(int width, int height, int frameCount);
-
     // Getters
     inline vec3 getTint() { return tint_; }
-    inline uint getBankSize() { return imageBank_.textureIds.size(); }
-    inline uint getCurrentFrame() { return currentFrame_; }
 
     // Setters
     inline void setTint(vec3 tint) { tint_ = tint; }
-    inline void setCurrentFrame(int frame) { currentFrame_ = frame; }
+
+    // AnimationFuncs
+    void createAnimation(int width, int height, int frameCount) override;
 
  private:
     vec3 tint_;
-    Image imageBank_;
-    uint currentFrame_;
 };

--- a/src/main/engine/SceneObject/headers/TextObject.hpp
+++ b/src/main/engine/SceneObject/headers/TextObject.hpp
@@ -32,9 +32,8 @@ typedef struct Character {
 class TextObject : public SceneObject {
  public:
     // Constructors
-    /// @todo Remove ObjectType - we render by camera now, so this isn't really needed...
-    explicit TextObject(string message, vec3 position, float scale, string fontPath, float charSpacing, uint programId,
-        string objectName, ObjectType type, GfxController *gfxController);
+    explicit TextObject(string message, vec3 position, float scale, string fontPath, float charSpacing, int charPoint,
+        uint programId, string objectName, ObjectType type, GfxController *gfxController);
     ~TextObject() override;
 
     // Setters
@@ -68,6 +67,8 @@ class TextObject : public SceneObject {
     unsigned int modelMatId_;
     unsigned int cutoffId_;
     unsigned int projectionId_;
+
+    int charPoint_;
 
     mat4 modelMat_;
     vec3 cutoff_;

--- a/src/main/engine/SceneObject/headers/UiObject.hpp
+++ b/src/main/engine/SceneObject/headers/UiObject.hpp
@@ -16,6 +16,10 @@
 #include <GameObject2D.hpp>
 #include <ColliderObject.hpp>
 
+#define POINTS_PER_TRIANGLE 3
+#define TRIANGLES_PER_QUAD 2
+#define QUADS_PER_UI_ELEM 9
+
 class UiObject : public GameObject2D {
  public:
     // Constructors
@@ -27,17 +31,20 @@ class UiObject : public GameObject2D {
     // Render method
     void render() override;
     void update() override;
-    void initializeShaderVars();
+    void initializeShaderVars() override;
     void initializeVertexData();
     std::shared_ptr<float[]> generateVertices(float x, float y, float iFx, float iFy);
     void generateVertexBase(std::shared_ptr<float[]> vertexData, int triIdx, float x, float y, float x2, float y2);
 
     // Set scale methods
-    void setHStretch(float scale);
-    void setWStretch(float scale);
+    void setHStretch(float wScale);
+    void setWStretch(float hScale);
 
     // Get scale methods
     vec3 getStretch();
+
+    // Animation functions
+    void createAnimation(int width, int height, int frameCount) override;
 
  private:
     unsigned int wScaleId_;

--- a/src/main/engine/SceneObject/src/CameraObject.cpp
+++ b/src/main/engine/SceneObject/src/CameraObject.cpp
@@ -4,9 +4,9 @@
  * @brief Implementation for CameraObject
  * @version 0.1
  * @date 2023-07-28
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 #include <string>
 #include <cstdio>

--- a/src/main/engine/SceneObject/src/GameObject.cpp
+++ b/src/main/engine/SceneObject/src/GameObject.cpp
@@ -41,7 +41,7 @@ GameObject::GameObject(Polygon *characterModel, vec3 position, vec3 rotation, fl
             hasTexture.push_back(1);  // Texture found for obj i
         }
     }
-    scaleMatrix_ = glm::scale(vec3(scale, scale, scale));
+    scaleMatrix_ = glm::scale(vec3(scale_, scale_, scale_));
     translateMatrix_ = glm::translate(mat4(1.0f), position);
     rotateMatrix_ = glm::rotate(mat4(1.0f), glm::radians(rotation[0]),
             vec3(1, 0, 0))  *glm::rotate(mat4(1.0f), glm::radians(rotation[1]),
@@ -183,7 +183,7 @@ void GameObject::render() {
                 vec3(0, 1, 0))  *glm::rotate(mat4(1.0f), glm::radians(rotation[2]),
                 vec3(0, 0, 1));
 
-        scaleMatrix_ = glm::scale(vec3(scale, scale, scale));
+        scaleMatrix_ = glm::scale(vec3(scale_, scale_, scale_));
         auto modelMatrix = translateMatrix_ * rotateMatrix_ * scaleMatrix_;
         // Send our shared variables over to our program (shader)
         gfxController_->sendFloat(luminanceId, luminance);

--- a/src/main/engine/SceneObject/src/GameObject2D.cpp
+++ b/src/main/engine/SceneObject/src/GameObject2D.cpp
@@ -18,7 +18,7 @@
 GameObject2D::GameObject2D(string texturePath, vec3 position, float scale, unsigned int programId,
         string objectName, ObjectType type, ObjectAnchor anchor, GfxController *gfxController): SceneObject(position,
     vec3(0.0f, 0.0f, 0.0f), objectName, scale, programId, type, gfxController),
-    TrackExt(texturePath, gfxController), texturePath_ { texturePath },
+    TrackExt(texturePath, this, gfxController), texturePath_ { texturePath },
     anchor_ { anchor } {
     printf("GameObject2D::GameObject2D: Creating 2D object %s\n", objectName.c_str());
 }

--- a/src/main/engine/SceneObject/src/GameObject2D.cpp
+++ b/src/main/engine/SceneObject/src/GameObject2D.cpp
@@ -17,7 +17,8 @@
 
 GameObject2D::GameObject2D(string texturePath, vec3 position, float scale, unsigned int programId,
         string objectName, ObjectType type, ObjectAnchor anchor, GfxController *gfxController): SceneObject(position,
-    vec3(0.0f, 0.0f, 0.0f), objectName, scale, programId, type, gfxController), texturePath_ { texturePath },
+    vec3(0.0f, 0.0f, 0.0f), objectName, scale, programId, type, gfxController),
+    TrackExt(texturePath, gfxController), texturePath_ { texturePath },
     anchor_ { anchor } {
     printf("GameObject2D::GameObject2D: Creating 2D object %s\n", objectName.c_str());
 }
@@ -26,25 +27,6 @@ void GameObject2D::initializeShaderVars() {
     gfxController_->setProgram(programId_);
     projectionId_ = gfxController_->getShaderVariable(programId_, "projection").get();
     modelMatId_ = gfxController_->getShaderVariable(programId_, "model").get();
-}
-
-/**
- * @brief Tightly packs texture data stored in an SDL_Surface to remove 4-byte alignment.
- * 
- * @param texture Valid SDL_Surface containing image data.
- * @return std::shared_ptr<uint8_t[]> Buffer containing tightly packed pixel data.
- */
-std::shared_ptr<uint8_t[]> GameObject2D::packSurface(SDL_Surface *texture) {
-    /* Tightly pack to remove 4 byte alignment on texture */
-    auto pixelSize = texture->format->BytesPerPixel;
-    std::shared_ptr<uint8_t[]> packedData(new uint8_t[texture->w * texture->h * pixelSize],
-        std::default_delete<uint8_t[]>());
-    for (int i = 0; i < texture->h; ++i) {
-        memcpy(&packedData.get()[i * pixelSize * texture->w],
-            &(reinterpret_cast<uint8_t *>(texture->pixels))[i * (texture->pitch)],
-            pixelSize * texture->w);
-    }
-    return packedData;
 }
 
 void GameObject2D::initializeTextureData() {
@@ -84,52 +66,6 @@ void GameObject2D::initializeTextureData() {
 void GameObject2D::setDimensions(int width, int height) {
     textureWidth_ = width;
     textureHeight_ = height;
-}
-
-void GameObject2D::initializeVertexData() {
-    // Perform anchor points here
-    auto x = 0.0f, y = 0.0f;
-    switch (anchor_) {
-        case BOTTOM_LEFT:
-            x = 0.0f;
-            y = 0.0f;
-            break;
-        case CENTER:
-            x = -1 * ((textureWidth_) / 2.0f);
-            y = -1 * ((textureHeight_) / 2.0f);
-            break;
-        case TOP_LEFT:
-            y = -1.0f * textureHeight_;
-            x = 0.0f;
-            break;
-        default:
-            fprintf(stderr, "GameObject2D::initializeVertexData: Unsupported anchor type %d\n", anchor_);
-            assert(false);
-            break;
-    }
-    auto x2 = x + (textureWidth_), y2 = y + (textureHeight_);
-    // Use textures to create each character as an independent object
-    gfxController_->initVao(&vao_);
-    gfxController_->bindVao(vao_);
-    gfxController_->generateBuffer(&vbo_);
-    gfxController_->bindBuffer(vbo_);
-    // update VBO for each character
-    // UV coordinate origin STARTS in the TOP left, NOT BOTTOM LEFT!!!
-    vertTexData_ = {
-        x, y2, 0.0f, 0.0f,
-        x, y, 0.0f, 1.0f,
-        x2, y2, 1.0f, 0.0f,
-
-        x2, y2, 1.0f, 0.0f,
-        x, y, 0.0f, 1.0f,
-        x2, y, 1.0f, 1.0f
-    };
-
-    // Send VBO data for each character to the currently bound buffer
-    gfxController_->sendBufferData(sizeof(float) * vertTexData_.size(), &vertTexData_[0]);
-    gfxController_->enableVertexAttArray(0, 4);
-    gfxController_->bindBuffer(0);
-    gfxController_->bindVao(0);
 }
 
 /// @todo Do something useful here

--- a/src/main/engine/SceneObject/src/SpriteObject.cpp
+++ b/src/main/engine/SceneObject/src/SpriteObject.cpp
@@ -4,9 +4,9 @@
  * @brief Implementation for SpriteObject
  * @version 0.1
  * @date 2023-07-28
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 #include <string>
 #include <cstdio>

--- a/src/main/engine/SceneObject/src/SpriteObject.cpp
+++ b/src/main/engine/SceneObject/src/SpriteObject.cpp
@@ -20,13 +20,59 @@ SpriteObject::SpriteObject(string spritePath, vec3 position, float scale, unsign
             spritePath, position, scale, programId, objectName, type, anchor, gfxController), tint_ { vec4(0) } {
     printf("SpriteObject::SpriteObject: Creating sprite %s\n", objectName.c_str());
     GameObject2D::initializeTextureData();
-    GameObject2D::initializeVertexData();
+    initializeVertexData();
     initializeShaderVars();
 }
 
 void SpriteObject::initializeShaderVars() {
     GameObject2D::initializeShaderVars();
     tintId_ = gfxController_->getShaderVariable(programId_, "tint").get();
+}
+
+void SpriteObject::initializeVertexData() {
+    // Perform anchor points here
+    auto x = 0.0f, y = 0.0f;
+    switch (anchor_) {
+        case BOTTOM_LEFT:
+            x = 0.0f;
+            y = 0.0f;
+            break;
+        case CENTER:
+            x = -1 * ((textureWidth_) / 2.0f);
+            y = -1 * ((textureHeight_) / 2.0f);
+            break;
+        case TOP_LEFT:
+            y = -1.0f * textureHeight_;
+            x = 0.0f;
+            break;
+        default:
+            fprintf(stderr, "SpriteObject::initializeVertexData: Unsupported anchor type %d\n", anchor_);
+            assert(false);
+            break;
+    }
+    auto x2 = x + (textureWidth_), y2 = y + (textureHeight_);
+    // Use textures to create each character as an independent object
+    gfxController_->initVao(&vao_);
+    gfxController_->bindVao(vao_);
+    gfxController_->generateBuffer(&vbo_);
+    gfxController_->bindBuffer(vbo_);
+    // update VBO for each character
+    // UV coordinate origin STARTS in the TOP left, NOT BOTTOM LEFT!!!
+    vertTexData_ = {
+        x, y2, 0.0f, 0.0f,
+        x, y, 0.0f, 1.0f,
+        x2, y2, 1.0f, 0.0f,
+
+        x2, y2, 1.0f, 0.0f,
+        x, y, 0.0f, 1.0f,
+        x2, y, 1.0f, 1.0f
+    };
+
+    // Send VBO data for each character to the currently bound buffer
+    gfxController_->sendBufferData(sizeof(float) * vertTexData_.size(), &vertTexData_[0]);
+    gfxController_->enableVertexAttArray(0, 4);
+    gfxController_->bindBuffer(0);
+    gfxController_->bindVao(0);
 }
 
 SpriteObject::~SpriteObject() {
@@ -38,7 +84,7 @@ void SpriteObject::render() {
             vec3(1, 0, 0))  *glm::rotate(mat4(1.0f), glm::radians(rotation[1]),
             vec3(0, 1, 0))  *glm::rotate(mat4(1.0f), glm::radians(rotation[2]),
             vec3(0, 0, 1));
-    scaleMatrix_ = glm::scale(vec3(scale, scale, scale));
+    scaleMatrix_ = glm::scale(vec3(scale_, scale_, scale_));
     modelMat_ = translateMatrix_ * rotateMatrix_ * scaleMatrix_;
     gfxController_->clear(GfxClearMode::DEPTH);
     gfxController_->setProgram(programId_);
@@ -67,91 +113,14 @@ void SpriteObject::update() {
     render();
 }
 
-/**
- * @brief Splits the sprite grid image into multiple equally sized frames. Re-opens the sprite and creates a texture
- * for each frame inside of the sprite grid. Creates frames in a sprite grid in sequential order from top left to
- * bottom right. Will assert if the dimensions of the image will not work.
- * 
- * If any asserts occur when running this function then something about the passed in image is bad. When this function
- * is called, the SpriteObject will no longer render itself as the passed in image. Instead, by default it will render
- * the first frame in the sprite grid and re-size the object itself to the dimensions of the first frame.
- * 
- * The image's width must be perfectly divisible by the width of each frame. The same is true for the height. The passed
- * in frameCount must also be less than or equal to the number of possible frames in the image given the width and height
- * of each frame.
- * 
- * @param width Of each frame in the sprite grid.
- * @param height Of each frame in the sprite grid.
- * @param frameCount The number of frames to pull from the sprite grid.
- */
-void SpriteObject::splitGrid(int width, int height, int frameCount) {
-    /* Re-open the image and process it */
-    auto image = IMG_Load(texturePath_.c_str());
-    if (image == nullptr) {
-        fprintf(stderr, "SpriteObject::splitGrid: Error - unable to open image %s\n",
-            texturePath_.c_str());
-        assert(0);
-        return;
-    }
+void SpriteObject::createAnimation(int width, int height, int frameCount) {
+    splitGrid(width, height, frameCount);
 
-    /* Validate the width, height and frame count */
-    assert(image->w % width == 0);
-    assert(image->h % height == 0);
-
-    /* No use in having a zero frame count, right? */
-    assert(frameCount > 0);
-
-    /* Detect the max frame count from the image dimensions */
-    auto numHorizontal = image->w / width;
-    auto numVertical = image->h / height;
-    auto maxFrames = numHorizontal * numVertical;
-
-    /* Determine the size of each pixel */
-    auto pixelSize = image->format->BytesPerPixel;
-    auto imageFormat = image->format->Amask ? TexFormat::RGBA : TexFormat::RGB;
-    assert(frameCount <= maxFrames);
-    std::unique_ptr<uint8_t[]> data;
-    imageBank_.width = width;
-    imageBank_.height = height;
-    auto packedData = GameObject2D::packSurface(image);
-
-    /* Grab frames LEFT TO RIGHT from image data */
-    for (int i = 0; i < frameCount; ++i) {
-        data = std::unique_ptr<uint8_t[]>(new uint8_t[width * height * pixelSize]);
-        /* This is going to suck, but I can't think of a clever solution.
-           Copy each frame line by line... */
-        auto imageRow = image->w * height * (i / numHorizontal);
-        for (int j = 0; j < height; ++j) {
-            /* Select the row of images in the sprite grid */
-
-            auto imageStart = (image->w * j) + imageRow + ((i % numHorizontal) * width);
-            memcpy(&data.get()[j * width * pixelSize], &packedData.get()[imageStart * pixelSize], width * pixelSize);
-        }
-
-        /* Create a texture for the current frame */
-        unsigned int textureId;
-
-        gfxController_->generateTexture(&textureId);
-        gfxController_->bindTexture(textureId);
-        gfxController_->sendTextureData(width, height, imageFormat, data.get());
-        gfxController_->setTexParam(TexParam::WRAP_MODE_S, TexVal(TexValType::CLAMP_TO_EDGE));
-        gfxController_->setTexParam(TexParam::WRAP_MODE_T, TexVal(TexValType::CLAMP_TO_EDGE));
-        gfxController_->setTexParam(TexParam::MAGNIFICATION_FILTER, TexVal(TexValType::NEAREST_NEIGHBOR));
-        gfxController_->setTexParam(TexParam::MINIFICATION_FILTER, TexVal(TexValType::NEAREST_MIPMAP));
-        gfxController_->setTexParam(TexParam::MIPMAP_LEVEL, TexVal(10));
-        gfxController_->generateMipMap();
-
-        /* Add the current image to the image bank */
-        imageBank_.textureIds.push_back(textureId);
-    }
-
-    SDL_FreeSurface(image);
+    // Update GameObject2D dimensions
 
     /* Update the dimensions of the SpriteObject to match the frame size */
-    GameObject2D::setDimensions(width, height);
+    setDimensions(width, height);
 
     /* GfxController will handle garbage collection of old data */
-    GameObject2D::initializeVertexData();
-
-    currentFrame_ = 0;  // Set the current frame to zero as the default
+    initializeVertexData();
 }

--- a/src/main/engine/SceneObject/src/TextObject.cpp
+++ b/src/main/engine/SceneObject/src/TextObject.cpp
@@ -13,10 +13,10 @@
 #include <string>
 #include <TextObject.hpp>
 
-TextObject::TextObject(string message, vec3 position, float scale, string fontPath, float charSpacing, uint programId,
+TextObject::TextObject(string message, vec3 position, float scale, string fontPath, float charSpacing, int charPoint, uint programId,
     string objectName, ObjectType type, GfxController *gfxController): SceneObject(position,
     vec3(0.0f, 0.0f, 0.0f), objectName, scale, programId, type, gfxController), charPadding_ { charSpacing },
-    message_  { message }, fontPath_ { fontPath }, cutoff_ { vec3(0.0f, 9000.0f, 0.0f) }, textColor_ { vec3(1.0f) } {
+    message_  { message }, fontPath_ { fontPath }, charPoint_ { charPoint }, cutoff_ { vec3(0.0f, 9000.0f, 0.0f) }, textColor_ { vec3(1.0f) } {
     printf("TextObject::TextObject: Creating message %s\n", message.c_str());
     initializeShaderVars();
     initializeText();
@@ -47,7 +47,7 @@ void TextObject::initializeText() {
         fprintf(stderr, "TextObject::initializeText: FREETYPE: Failed to load font\n");
         throw std::runtime_error("Failed to load font");
     } else {
-        FT_Set_Pixel_Sizes(face, 0, 96);
+        FT_Set_Pixel_Sizes(face, 0, charPoint_);
         for (unsigned char c = 0; c < 128; c++) {
             if (FT_Load_Char(face, c, FT_LOAD_RENDER)) {
                 fprintf(stderr, "TextObject::initializeText: FREETYPE: Failed to load glyph\n");

--- a/src/main/engine/SceneObject/src/TextObject.cpp
+++ b/src/main/engine/SceneObject/src/TextObject.cpp
@@ -4,19 +4,20 @@
  * @brief Implementation of TextObject
  * @version 0.1
  * @date 2023-07-28
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 #include <cstdio>
 #include <vector>
 #include <string>
 #include <TextObject.hpp>
 
-TextObject::TextObject(string message, vec3 position, float scale, string fontPath, float charSpacing, int charPoint, uint programId,
-    string objectName, ObjectType type, GfxController *gfxController): SceneObject(position,
+TextObject::TextObject(string message, vec3 position, float scale, string fontPath, float charSpacing, int charPoint,
+    uint programId, string objectName, ObjectType type, GfxController *gfxController): SceneObject(position,
     vec3(0.0f, 0.0f, 0.0f), objectName, scale, programId, type, gfxController), charPadding_ { charSpacing },
-    message_  { message }, fontPath_ { fontPath }, charPoint_ { charPoint }, cutoff_ { vec3(0.0f, 9000.0f, 0.0f) }, textColor_ { vec3(1.0f) } {
+    message_  { message }, fontPath_ { fontPath }, charPoint_ { charPoint }, cutoff_ { vec3(0.0f, 9000.0f, 0.0f) },
+    textColor_ { vec3(1.0f) } {
     printf("TextObject::TextObject: Creating message %s\n", message.c_str());
     initializeShaderVars();
     initializeText();
@@ -160,7 +161,7 @@ void TextObject::update() {
 /**
  * @brief Update the text object with a new message. If the incoming message is the same as the existing message, then
  * the message is not updated.
- * 
+ *
  * @param message Incoming message to set TextObject to.
  */
 void TextObject::setMessage(string message) {

--- a/src/main/engine/SceneObject/src/TextObject.cpp
+++ b/src/main/engine/SceneObject/src/TextObject.cpp
@@ -87,10 +87,10 @@ void TextObject::createMessage() {
     // Use textures to create each character as an independent object
     for (auto character : message_) {
         Character ch = characters[character];
-        float xpos = x + ch.Bearing.x * scale;
-        float ypos = y - (ch.Size.y - ch.Bearing.y) * scale;
-        float w = ch.Size.x * scale;
-        float h = ch.Size.y * scale;
+        float xpos = x + ch.Bearing.x * scale_;
+        float ypos = y - (ch.Size.y - ch.Bearing.y) * scale_;
+        float w = ch.Size.x * scale_;
+        float h = ch.Size.y * scale_;
         if (character == '\n') {
             x = 0;
             y -= (h * (spacing + 1.0f));

--- a/src/main/engine/SceneObject/src/UiObject.cpp
+++ b/src/main/engine/SceneObject/src/UiObject.cpp
@@ -90,8 +90,8 @@ void UiObject::initializeVertexData() {
             y = 0.0f;
             break;
         case CENTER:
-            x = -1 * ((textureWidth_) / 2.0f);
-            y = -1 * ((textureHeight_) / 6.0f);
+            x = -1 * ((textureWidth_ * scale_) / 2.0f);
+            y = -1 * ((textureHeight_ * scale_) / 2.0f);
             break;
         case TOP_LEFT:
             y = -1.0f * textureHeight_ / 3.0f;
@@ -102,8 +102,8 @@ void UiObject::initializeVertexData() {
             assert(false);
             break;
     }
-    auto incrementFactorX = (textureWidth_ / 3.0f);
-    auto incrementFactorY = (textureHeight_ / 3.0f);
+    auto incrementFactorX = (textureWidth_ * scale_ / 3.0f);
+    auto incrementFactorY = (textureHeight_ * scale_ / 3.0f);
     // Use textures to create each character as an independent object
     gfxController_->initVao(&vao_);
     gfxController_->bindVao(vao_);
@@ -138,9 +138,9 @@ void UiObject::render() {
             vec3(1, 0, 0))  *glm::rotate(mat4(1.0f), glm::radians(rotation[1]),
             vec3(0, 1, 0))  *glm::rotate(mat4(1.0f), glm::radians(rotation[2]),
             vec3(0, 0, 1));
-    scaleMatrix_ = glm::scale(vec3(scale_, scale_, scale_));
+    // scaleMatrix_ = glm::scale(vec3(scale_, scale_, scale_));
     // modelMat_ = translateMatrix_ * rotateMatrix_ * scaleMatrix_;
-    modelMat_ = translateMatrix_ * scaleMatrix_;
+    modelMat_ = translateMatrix_;
     gfxController_->clear(GfxClearMode::DEPTH);
     gfxController_->setProgram(programId_);
     gfxController_->polygonRenderMode(RenderMode::FILL);

--- a/src/main/engine/SceneObject/test/src/SpriteObjectTests.cpp
+++ b/src/main/engine/SceneObject/test/src/SpriteObjectTests.cpp
@@ -4,9 +4,9 @@
  * @brief Test suite for SpriteObject functions.
  * @version 0.1
  * @date 2023-07-28
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 #include <gtest/gtest.h>
 #include <vector>
@@ -24,10 +24,10 @@ const unsigned int dummyVao = 0xBEEF;
 const char *testSpritePath = "../src/resources/images/test_image.png";
 /**
  * @brief Launches google test suite defined in file
- * 
- * @param argc 
- * @param argv 
- * @return int 
+ *
+ * @param argc
+ * @param argv
+ * @return int
  */
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
@@ -81,7 +81,7 @@ void GivenASpriteObject::TearDown() {
 /**
  * @brief Initializes mocks for the GfxController. Most mocks just define default behavior, but
  * the EXPECT_CALL mocks will capture generated frame data from the SpriteObject.
- * 
+ *
  */
 void GivenASpriteObject::initMocks() {
     // Set up the mock GfxController
@@ -144,7 +144,7 @@ void GivenASpriteObject::initMocks() {
  */
 TEST_F(GivenASpriteObject, WhenSplitGridCalled_ThenImagesSplitSuccessfully) {
     /* Preparation/Action */
-    spriteObject_->splitGrid(width, height, numFrames);
+    spriteObject_->createAnimation(width, height, numFrames);
 
     /* Validation */
     auto frameSize = width * height * bytesPerPixel;
@@ -155,4 +155,3 @@ TEST_F(GivenASpriteObject, WhenSplitGridCalled_ThenImagesSplitSuccessfully) {
         EXPECT_EQ(0, result);
     }
 }
-

--- a/src/main/engine/SceneObjectExt/headers/TrackExt.hpp
+++ b/src/main/engine/SceneObjectExt/headers/TrackExt.hpp
@@ -7,14 +7,15 @@
 
 #pragma once
 #include <string>
+#include <memory>
 #include <SDL_image.h>
 #include <Image.hpp>
 #include <GfxController.hpp>
 #include <SceneObject.hpp>
 class TrackExt {
  public:
-    inline explicit TrackExt(std::string imagePath, SceneObject *obj, GfxController *gfxController) : imagePath_ { imagePath },
-        obj_ { obj }, extGfx_ { gfxController } {}
+    inline explicit TrackExt(std::string imagePath, SceneObject *obj, GfxController *gfxController) :
+        imagePath_ { imagePath }, obj_ { obj }, extGfx_ { gfxController } {}
 
     // Getters
     inline uint getBankSize() { return imageBank_.textureIds.size(); }

--- a/src/main/engine/SceneObjectExt/headers/TrackExt.hpp
+++ b/src/main/engine/SceneObjectExt/headers/TrackExt.hpp
@@ -10,17 +10,21 @@
 #include <SDL_image.h>
 #include <Image.hpp>
 #include <GfxController.hpp>
+#include <SceneObject.hpp>
 class TrackExt {
  public:
-    inline explicit TrackExt(std::string imagePath, GfxController *gfxController) : imagePath_ { imagePath },
-        extGfx_ { gfxController } {}
+    inline explicit TrackExt(std::string imagePath, SceneObject *obj, GfxController *gfxController) : imagePath_ { imagePath },
+        obj_ { obj }, extGfx_ { gfxController } {}
 
     // Getters
     inline uint getBankSize() { return imageBank_.textureIds.size(); }
     inline uint getCurrentFrame() { return currentFrame_; }
+    inline SceneObject *getObj() { return obj_; }
 
     // Setters
     inline void setCurrentFrame(int frame) { currentFrame_ = frame; }
+     // Animation Methods
+     virtual void createAnimation(int width, int height, int frameCount) = 0;
  protected:
     void splitGrid(int width, int height, int frameCount);
     std::shared_ptr<uint8_t[]> packSurface(SDL_Surface *texture);
@@ -28,5 +32,6 @@ class TrackExt {
     uint currentFrame_;
     std::string imagePath_;
  private:
+    SceneObject *obj_;
     GfxController *extGfx_;
 };

--- a/src/main/engine/SceneObjectExt/headers/TrackExt.hpp
+++ b/src/main/engine/SceneObjectExt/headers/TrackExt.hpp
@@ -1,0 +1,32 @@
+/**
+ * @file TrackExt.hpp
+ * @author Christian Galvez
+ * @brief Extension that allows for track animations
+ * @copyright Copyright (c) 2025
+ */
+
+#pragma once
+#include <string>
+#include <SDL_image.h>
+#include <Image.hpp>
+#include <GfxController.hpp>
+class TrackExt {
+ public:
+    inline explicit TrackExt(std::string imagePath, GfxController *gfxController) : imagePath_ { imagePath },
+        extGfx_ { gfxController } {}
+
+    // Getters
+    inline uint getBankSize() { return imageBank_.textureIds.size(); }
+    inline uint getCurrentFrame() { return currentFrame_; }
+
+    // Setters
+    inline void setCurrentFrame(int frame) { currentFrame_ = frame; }
+ protected:
+    void splitGrid(int width, int height, int frameCount);
+    std::shared_ptr<uint8_t[]> packSurface(SDL_Surface *texture);
+    Image imageBank_;
+    uint currentFrame_;
+    std::string imagePath_;
+ private:
+    GfxController *extGfx_;
+};

--- a/src/main/engine/SceneObjectExt/headers/TrackExt.hpp
+++ b/src/main/engine/SceneObjectExt/headers/TrackExt.hpp
@@ -28,7 +28,6 @@ class TrackExt {
      virtual void createAnimation(int width, int height, int frameCount) = 0;
  protected:
     void splitGrid(int width, int height, int frameCount);
-    std::shared_ptr<uint8_t[]> packSurface(SDL_Surface *texture);
     Image imageBank_;
     uint currentFrame_;
     std::string imagePath_;

--- a/src/main/engine/SceneObjectExt/src/TrackExt.cpp
+++ b/src/main/engine/SceneObjectExt/src/TrackExt.cpp
@@ -5,25 +5,27 @@
  * @copyright Copyright (c) 2025
  */
 
-#include <memory>
 #include <TrackExt.hpp>
+#include <assert.h>
+#include <memory>
+#include <cstdio>
 #include <GfxController.hpp>
 #include <SDL_image.h>
-#include <assert.h>
+
 
 /**
  * @brief Splits the sprite grid image into multiple equally sized frames. Re-opens the sprite and creates a texture
  * for each frame inside of the sprite grid. Creates frames in a sprite grid in sequential order from top left to
  * bottom right. Will assert if the dimensions of the image will not work.
- * 
+ *
  * If any asserts occur when running this function then something about the passed in image is bad. When this function
  * is called, the SpriteObject will no longer render itself as the passed in image. Instead, by default it will render
  * the first frame in the sprite grid and re-size the object itself to the dimensions of the first frame.
- * 
+ *
  * The image's width must be perfectly divisible by the width of each frame. The same is true for the height. The passed
  * in frameCount must also be less than or equal to the number of possible frames in the image given the width and height
  * of each frame.
- * 
+ *
  * @param width Of each frame in the sprite grid.
  * @param height Of each frame in the sprite grid.
  * @param frameCount The number of frames to pull from the sprite grid.
@@ -96,7 +98,7 @@ void TrackExt::splitGrid(int width, int height, int frameCount) {
 
 /**
  * @brief Tightly packs texture data stored in an SDL_Surface to remove 4-byte alignment.
- * 
+ *
  * @param texture Valid SDL_Surface containing image data.
  * @return std::shared_ptr<uint8_t[]> Buffer containing tightly packed pixel data.
  */

--- a/src/main/engine/SceneObjectExt/src/TrackExt.cpp
+++ b/src/main/engine/SceneObjectExt/src/TrackExt.cpp
@@ -1,0 +1,114 @@
+/**
+ * @file TrackExt.cpp
+ * @brief Function definitions for animation track support.
+ * @author Christian Galvez
+ * @copyright Copyright (c) 2025
+ */
+
+#include <memory>
+#include <TrackExt.hpp>
+#include <GfxController.hpp>
+#include <SDL_image.h>
+#include <assert.h>
+
+/**
+ * @brief Splits the sprite grid image into multiple equally sized frames. Re-opens the sprite and creates a texture
+ * for each frame inside of the sprite grid. Creates frames in a sprite grid in sequential order from top left to
+ * bottom right. Will assert if the dimensions of the image will not work.
+ * 
+ * If any asserts occur when running this function then something about the passed in image is bad. When this function
+ * is called, the SpriteObject will no longer render itself as the passed in image. Instead, by default it will render
+ * the first frame in the sprite grid and re-size the object itself to the dimensions of the first frame.
+ * 
+ * The image's width must be perfectly divisible by the width of each frame. The same is true for the height. The passed
+ * in frameCount must also be less than or equal to the number of possible frames in the image given the width and height
+ * of each frame.
+ * 
+ * @param width Of each frame in the sprite grid.
+ * @param height Of each frame in the sprite grid.
+ * @param frameCount The number of frames to pull from the sprite grid.
+ */
+void TrackExt::splitGrid(int width, int height, int frameCount) {
+    /* Re-open the image and process it */
+    auto image = IMG_Load(imagePath_.c_str());
+    if (image == nullptr) {
+        fprintf(stderr, "SpriteObject::splitGrid: Error - unable to open image %s\n",
+            imagePath_.c_str());
+        assert(0);
+        return;
+    }
+
+    /* Validate the width, height and frame count */
+    assert(image->w % width == 0);
+    assert(image->h % height == 0);
+
+    /* No use in having a zero frame count, right? */
+    assert(frameCount > 0);
+
+    /* Detect the max frame count from the image dimensions */
+    auto numHorizontal = image->w / width;
+    auto numVertical = image->h / height;
+    auto maxFrames = numHorizontal * numVertical;
+
+    /* Determine the size of each pixel */
+    auto pixelSize = image->format->BytesPerPixel;
+    auto imageFormat = image->format->Amask ? TexFormat::RGBA : TexFormat::RGB;
+    assert(frameCount <= maxFrames);
+    std::unique_ptr<uint8_t[]> data;
+    imageBank_.width = width;
+    imageBank_.height = height;
+    auto packedData = packSurface(image);
+
+    /* Grab frames LEFT TO RIGHT from image data */
+    for (int i = 0; i < frameCount; ++i) {
+        data = std::unique_ptr<uint8_t[]>(new uint8_t[width * height * pixelSize]);
+        /* This is going to suck, but I can't think of a clever solution.
+           Copy each frame line by line... */
+        auto imageRow = image->w * height * (i / numHorizontal);
+        for (int j = 0; j < height; ++j) {
+            /* Select the row of images in the sprite grid */
+
+            auto imageStart = (image->w * j) + imageRow + ((i % numHorizontal) * width);
+            memcpy(&data.get()[j * width * pixelSize], &packedData.get()[imageStart * pixelSize], width * pixelSize);
+        }
+
+        /* Create a texture for the current frame */
+        unsigned int textureId;
+
+        extGfx_->generateTexture(&textureId);
+        extGfx_->bindTexture(textureId);
+        extGfx_->sendTextureData(width, height, imageFormat, data.get());
+        extGfx_->setTexParam(TexParam::WRAP_MODE_S, TexVal(TexValType::CLAMP_TO_EDGE));
+        extGfx_->setTexParam(TexParam::WRAP_MODE_T, TexVal(TexValType::CLAMP_TO_EDGE));
+        extGfx_->setTexParam(TexParam::MAGNIFICATION_FILTER, TexVal(TexValType::NEAREST_NEIGHBOR));
+        extGfx_->setTexParam(TexParam::MINIFICATION_FILTER, TexVal(TexValType::NEAREST_MIPMAP));
+        extGfx_->setTexParam(TexParam::MIPMAP_LEVEL, TexVal(10));
+        extGfx_->generateMipMap();
+
+        /* Add the current image to the image bank */
+        imageBank_.textureIds.push_back(textureId);
+    }
+
+    SDL_FreeSurface(image);
+
+    currentFrame_ = 0;  // Set the current frame to zero as the default
+}
+
+/**
+ * @brief Tightly packs texture data stored in an SDL_Surface to remove 4-byte alignment.
+ * 
+ * @param texture Valid SDL_Surface containing image data.
+ * @return std::shared_ptr<uint8_t[]> Buffer containing tightly packed pixel data.
+ */
+std::shared_ptr<uint8_t[]> TrackExt::packSurface(SDL_Surface *texture) {
+    /* Tightly pack to remove 4 byte alignment on texture */
+    auto pixelSize = texture->format->BytesPerPixel;
+    std::shared_ptr<uint8_t[]> packedData(new uint8_t[texture->w * texture->h * pixelSize],
+        std::default_delete<uint8_t[]>());
+    for (int i = 0; i < texture->h; ++i) {
+        memcpy(&packedData.get()[i * pixelSize * texture->w],
+            &(reinterpret_cast<uint8_t *>(texture->pixels))[i * (texture->pitch)],
+            pixelSize * texture->w);
+    }
+    return packedData;
+}

--- a/src/main/engine/SceneObjectExt/src/TrackExt.cpp
+++ b/src/main/engine/SceneObjectExt/src/TrackExt.cpp
@@ -95,22 +95,3 @@ void TrackExt::splitGrid(int width, int height, int frameCount) {
 
     currentFrame_ = 0;  // Set the current frame to zero as the default
 }
-
-/**
- * @brief Tightly packs texture data stored in an SDL_Surface to remove 4-byte alignment.
- *
- * @param texture Valid SDL_Surface containing image data.
- * @return std::shared_ptr<uint8_t[]> Buffer containing tightly packed pixel data.
- */
-std::shared_ptr<uint8_t[]> TrackExt::packSurface(SDL_Surface *texture) {
-    /* Tightly pack to remove 4 byte alignment on texture */
-    auto pixelSize = texture->format->BytesPerPixel;
-    std::shared_ptr<uint8_t[]> packedData(new uint8_t[texture->w * texture->h * pixelSize],
-        std::default_delete<uint8_t[]>());
-    for (int i = 0; i < texture->h; ++i) {
-        memcpy(&packedData.get()[i * pixelSize * texture->w],
-            &(reinterpret_cast<uint8_t *>(texture->pixels))[i * (texture->pitch)],
-            pixelSize * texture->w);
-    }
-    return packedData;
-}


### PR DESCRIPTION
# Changes

### Context
<!--- Give a brief description of your changes. -->
* Added methods to the GameInstance class to help with asynchronous games.
* Re-based animation track methods to a separate TrackExt class. This allows any type of SceneObject to easily implement texture track support.
* Separated game cameras to a separate list. Not sure why I wanted all GameInstance scene objects to be in a single list. Using a separate list makes it way more efficient.
* Added an argument to createText that allows a user to specify the font point to use for font textures.
* Fixed UI object anchoring AGAIN. It should actually be good now.
* Lots of whitespace changes. Please ignore them. I started using Zed as my text editor and it just did all that weird stuff automatically. Nothing harmful, just a bigger diff than necessary.
### Issues
<!--- List any relevant GitHub issues this PR is addressing here. -->

### Considerations
<!--- If any major decisions, breaking changes, or redesigns were made, describe them here. Give a brief summary describing how you came to this conclusion. -->
This will break existing games. Some UI elements may need to be re-positioned. A font point of 48 was used previously, so use this value if you don't want to re-scale text. Recent engine versions use a font point of 96, so use that for high DPI text.

We should start moving Doxygen comments on methods and functions to their respective header files. Since studious is a library now, it would be useful to move documentation to the header files installed on your sysroot so they are easier to immediately access.
## QA Checklist

- [x] I ran `cpplint --linelength=120 --recursive src/main/` and corrected any issues.
- [x] I added unit tests to relevant code.
- [x] I added/revised Doxygen documentation on new code.
- [x] I can compile using G++.
- [x] I am passing all unit tests. (`./setupBuild.sh -t`)
