### PR TITLE
Refactor getProgramId Code

### DIFF
--- a/src/main/engine/GfxController/headers/DummyGfxController.hpp
+++ b/src/main/engine/GfxController/headers/DummyGfxController.hpp
@@ -1,12 +1,12 @@
 /**
  * @file DummyGfxController.hpp
  * @author Christian Galvez
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2024-01-21
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 #pragma once
 #include <string>
@@ -23,9 +23,9 @@ class DummyGfxController : public GfxController {
     GfxResult<unsigned int> sendTextureData(unsigned int width, unsigned int height, TexFormat format, void *data);
     GfxResult<int>  getShaderVariable(unsigned int, const char *);
     GfxResult<int>  cleanup();
-    GfxResult<unsigned int> getProgramId(uint);
+    GfxResult<unsigned int> getProgramId(string);
     GfxResult<unsigned int> setProgram(unsigned int);
-    GfxResult<unsigned int> loadShaders(string, string);
+    GfxResult<unsigned int> loadShaders(string, string, string);
     GfxResult<unsigned int> sendFloat(unsigned int variableId, float data);
     GfxResult<unsigned int> sendFloatVector(unsigned int variableId, size_t count, float *data);
     GfxResult<unsigned int> polygonRenderMode(RenderMode mode);

--- a/src/main/engine/GfxController/headers/GfxController.hpp
+++ b/src/main/engine/GfxController/headers/GfxController.hpp
@@ -82,6 +82,12 @@ class GfxResult {
     T data_;
 };
 
+struct ProgramData {
+    string programName;
+    string vertexShaderPath;
+    string fragmentShaderPath;
+};
+
 class GfxController {
  public:
     virtual GfxResult<int> init() = 0;
@@ -92,9 +98,21 @@ class GfxController {
     virtual GfxResult<unsigned int> sendTextureData(unsigned int width, unsigned int height, TexFormat format,
         void *data) = 0;
     virtual GfxResult<int>  getShaderVariable(unsigned int, const char *) = 0;
-    virtual GfxResult<unsigned int> getProgramId(uint) = 0;
+    /**
+     * @brief Fetches the program ID that belongs to the given name. Returns a
+     * GFX_FAILURE if the program does not exist, or is inactive.
+     */
+    virtual GfxResult<unsigned int> getProgramId(string) = 0;
     virtual GfxResult<unsigned int> setProgram(unsigned int) = 0;
-    virtual GfxResult<unsigned int> loadShaders(string, string) = 0;
+    /**
+     * @brief Compiles the provided shaders and creates a new program ID on success.
+     * @param programName The name to give the newly created program.
+     * @param vertShadedPath Path to the vertex shader to compile.
+     * @param fragShaderPath Path to the fragment sahder to compile.
+     * @return OK on success, FAILURE on failure. When successful, the program ID will be returned in the
+     * GfxResult's data field, accessable via GfxResult::get().
+     */
+    virtual GfxResult<unsigned int> loadShaders(string programName, string vertShaderPath, string fragShaderPath) = 0;
     virtual GfxResult<unsigned int> sendFloat(unsigned int variableId, float data) = 0;
     virtual GfxResult<unsigned int> sendFloatVector(unsigned int variableId, size_t count, float *data) = 0;
     virtual GfxResult<unsigned int> polygonRenderMode(RenderMode mode) = 0;

--- a/src/main/engine/GfxController/headers/MockGfxController.hpp
+++ b/src/main/engine/GfxController/headers/MockGfxController.hpp
@@ -23,9 +23,9 @@ class MockGfxController : public GfxController {
     MOCK_METHOD(GfxResult<unsigned int>, sendBufferData, (size_t, void *), (override));
     MOCK_METHOD(GfxResult<unsigned int>, sendTextureData, (unsigned int, unsigned int, TexFormat, void *), (override));
     MOCK_METHOD(GfxResult<int>, getShaderVariable, (unsigned int, const char *), (override));
-    MOCK_METHOD(GfxResult<unsigned int>, getProgramId, (uint), (override));
+    MOCK_METHOD(GfxResult<unsigned int>, getProgramId, (string), (override));
     MOCK_METHOD(GfxResult<unsigned int>, setProgram, (unsigned int), (override));
-    MOCK_METHOD(GfxResult<unsigned int>, loadShaders, (string, string), (override));
+    MOCK_METHOD(GfxResult<unsigned int>, loadShaders, (string, string, string), (override));
     MOCK_METHOD(GfxResult<unsigned int>, sendFloat, (unsigned int, float), (override));
     MOCK_METHOD(GfxResult<unsigned int>, sendFloatVector, (unsigned int, size_t, float *), (override));
     MOCK_METHOD(GfxResult<unsigned int>, polygonRenderMode, (RenderMode), (override));

--- a/src/main/engine/GfxController/headers/OpenGlEsGfxController.hpp
+++ b/src/main/engine/GfxController/headers/OpenGlEsGfxController.hpp
@@ -1,12 +1,12 @@
 /**
  * @file OpenGlEsGfxController.hpp
  * @author Christian Galvez
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2024-01-21
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 
 #pragma once
@@ -37,9 +37,9 @@ class OpenGlEsGfxController : public GfxController {
     GfxResult<unsigned int> sendTextureData(unsigned int width, unsigned int height, TexFormat format, void *data);
     GfxResult<int> getShaderVariable(unsigned int, const char *);
     GfxResult<int> cleanup();
-    GfxResult<unsigned int> getProgramId(uint);
+    GfxResult<unsigned int> getProgramId(string);
     GfxResult<unsigned int> setProgram(unsigned int programId);
-    GfxResult<unsigned int> loadShaders(string, string);
+    GfxResult<unsigned int> loadShaders(string, string, string);
     GfxResult<unsigned int> sendFloat(unsigned int variableId, float data);
     GfxResult<unsigned int> sendFloatVector(unsigned int variableId, size_t count, float *data);
     GfxResult<unsigned int> polygonRenderMode(RenderMode mode);
@@ -65,7 +65,7 @@ class OpenGlEsGfxController : public GfxController {
     std::shared_ptr<uint8_t[]> convertToRgba(size_t size, uint8_t *data);
 
  private:
-    vector<unsigned int> programIdList_;
+    map<string, uint> programIdMap_;
     vector<float> bgColor_;
     // VAO -> (VBO -> Attribute Data)
     map<unsigned int, map<unsigned int, GfxVaoData>> vaoBindData_;

--- a/src/main/engine/GfxController/headers/OpenGlGfxController.hpp
+++ b/src/main/engine/GfxController/headers/OpenGlGfxController.hpp
@@ -1,12 +1,12 @@
 /**
  * @file OpenGlGfxController.hpp
  * @author Christian Galvez
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2024-01-21
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 
 #pragma once
@@ -31,9 +31,9 @@ class OpenGlGfxController : public GfxController {
     GfxResult<unsigned int> sendTextureData(unsigned int width, unsigned int height, TexFormat format, void *data);
     GfxResult<int> getShaderVariable(unsigned int, const char *);
     GfxResult<int> cleanup();
-    GfxResult<unsigned int> getProgramId(uint);
+    GfxResult<unsigned int> getProgramId(string);
     GfxResult<unsigned int> setProgram(unsigned int programId);
-    GfxResult<unsigned int> loadShaders(string, string);
+    GfxResult<unsigned int> loadShaders(string, string, string);
     GfxResult<unsigned int> sendFloat(unsigned int variableId, float data);
     GfxResult<unsigned int> sendFloatVector(unsigned int variableId, size_t count, float *data);
     GfxResult<unsigned int> polygonRenderMode(RenderMode mode);
@@ -58,7 +58,7 @@ class OpenGlGfxController : public GfxController {
     void updateOpenGl();
 
  private:
-    vector<unsigned int> programIdList_;
+    map<string, uint> programIdMap_;
 
     /* Objects tracked internally to free when closing */
     vector<unsigned int> vaoList_;

--- a/src/main/engine/GfxController/src/DummyGfxController.cpp
+++ b/src/main/engine/GfxController/src/DummyGfxController.cpp
@@ -1,12 +1,12 @@
 /**
  * @file DummyGfxController.cpp
  * @author Christian Galvez
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2024-01-21
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 #include <string>
 #include <iostream>
@@ -51,12 +51,12 @@ GfxResult<int> DummyGfxController::cleanup() {
     return GFX_OK(int);
 }
 
-GfxResult<unsigned int> DummyGfxController::getProgramId(uint index) {
+GfxResult<unsigned int> DummyGfxController::getProgramId(string programName) {
     cout << "GfxController::getProgramId" << endl;
     return GFX_OK(unsigned int);
 }
 
-GfxResult<unsigned int> DummyGfxController::loadShaders(string vertexPath, string fragmentPath) {
+GfxResult<unsigned int> DummyGfxController::loadShaders(string programName, string vertexPath, string fragmentPath) {
     cout << "GfxController::loadShaders" << endl;
     return GFX_OK(unsigned int);
 }
@@ -186,4 +186,3 @@ void DummyGfxController::setBgColor(float r, float g, float b) {
     printf("GfxController::setBgColor: %f, %f, %f\n",
         r, g, b);
 }
-

--- a/src/main/engine/GfxController/src/OpenGlEsGfxController.cpp
+++ b/src/main/engine/GfxController/src/OpenGlEsGfxController.cpp
@@ -177,7 +177,8 @@ GfxResult<unsigned int> OpenGlEsGfxController::getProgramId(string programName) 
  * @param fragmentShader Path to the fragmentShader to compile on the system
  * @return GfxResult<unsigned int> OK with the newly created programId; FAILURE otherwise.
  */
-GfxResult<unsigned int> OpenGlEsGfxController::loadShaders(string programName, string vertexShader, string fragmentShader) {
+GfxResult<unsigned int> OpenGlEsGfxController::loadShaders(string programName, string vertexShader,
+    string fragmentShader) {
     unsigned int vertexShaderID = glCreateShader(GL_VERTEX_SHADER);
     unsigned int fragmentShaderID = glCreateShader(GL_FRAGMENT_SHADER);
     int logLength;

--- a/src/main/engine/GfxController/src/OpenGlEsGfxController.cpp
+++ b/src/main/engine/GfxController/src/OpenGlEsGfxController.cpp
@@ -160,18 +160,14 @@ GfxResult<unsigned int> OpenGlEsGfxController::generateTexture(unsigned int *tex
     return GFX_OK(unsigned int);
 }
 
-/**
- * @brief Gets a programId for a specific index in the programIdList.
- *
- * @param index in the programId list
- * @return GfxResult<unsigned int> OK with returned program ID when successful; FAILURE otherwise.
- */
-GfxResult<unsigned int> OpenGlEsGfxController::getProgramId(uint index) {
-    // Boundary check index
-    if (index > programIdList_.size()) {
-        return GfxResult<unsigned int>(GfxApiResult::FAILURE, UINT_MAX);
+GfxResult<unsigned int> OpenGlEsGfxController::getProgramId(string programName) {
+    auto result = GFX_FAILURE(uint);
+    // Check if the program exists in the program ID map
+    auto pimit = programIdMap_.find(programName);
+    if (pimit != programIdMap_.end()) {
+        result = GfxResult<uint>(GfxApiResult::OK, pimit->second);
     }
-    return GfxResult<unsigned int>(GfxApiResult::OK, programIdList_[index]);
+    return result;
 }
 
 /**
@@ -181,7 +177,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::getProgramId(uint index) {
  * @param fragmentShader Path to the fragmentShader to compile on the system
  * @return GfxResult<unsigned int> OK with the newly created programId; FAILURE otherwise.
  */
-GfxResult<unsigned int> OpenGlEsGfxController::loadShaders(string vertexShader, string fragmentShader) {
+GfxResult<unsigned int> OpenGlEsGfxController::loadShaders(string programName, string vertexShader, string fragmentShader) {
     unsigned int vertexShaderID = glCreateShader(GL_VERTEX_SHADER);
     unsigned int fragmentShaderID = glCreateShader(GL_FRAGMENT_SHADER);
     int logLength;
@@ -250,7 +246,7 @@ GfxResult<unsigned int> OpenGlEsGfxController::loadShaders(string vertexShader, 
     glDeleteShader(vertexShaderID);
     glDeleteShader(fragmentShaderID);
     // Add programId to programIdList
-    programIdList_.push_back(programId);
+    programIdMap_[programName] = programId;
 
     printf("OpenGlEsGfxController::loadShaders: Created programId %d\n", programId);
 

--- a/src/main/engine/GfxController/src/OpenGlGfxController.cpp
+++ b/src/main/engine/GfxController/src/OpenGlGfxController.cpp
@@ -8,13 +8,12 @@
  * @copyright Copyright (c) 2024
  *
  */
-#include "GfxController.hpp"
+#include <OpenGlGfxController.hpp>
 #include <string>
 #include <iostream>
 #include <vector>
 #include <cstdio>
 #include <algorithm>
-#include <OpenGlGfxController.hpp>
 
 /**
  * @brief Generates a buffer in the OpenGL context
@@ -159,7 +158,8 @@ GfxResult<unsigned int> OpenGlGfxController::getProgramId(string programName) {
  * @param fragmentShader Path to the fragmentShader to compile on the system
  * @return GfxResult<unsigned int> OK with the newly created programId; FAILURE otherwise.
  */
-GfxResult<unsigned int> OpenGlGfxController::loadShaders(string programName, string vertexShader, string fragmentShader) {
+GfxResult<unsigned int> OpenGlGfxController::loadShaders(string programName, string vertexShader,
+    string fragmentShader) {
     printf("Creaeting vertex shader id\n");
     unsigned int vertexShaderID = glCreateShader(GL_VERTEX_SHADER);
     printf("Creaeting frag shader id\n");

--- a/src/main/engine/GfxController/src/OpenGlGfxController.cpp
+++ b/src/main/engine/GfxController/src/OpenGlGfxController.cpp
@@ -8,6 +8,7 @@
  * @copyright Copyright (c) 2024
  *
  */
+#include "GfxController.hpp"
 #include <string>
 #include <iostream>
 #include <vector>
@@ -141,18 +142,14 @@ GfxResult<unsigned int> OpenGlGfxController::generateTexture(unsigned int *textu
     return GFX_OK(unsigned int);
 }
 
-/**
- * @brief Gets a programId for a specific index in the programIdList.
- *
- * @param index in the programId list
- * @return GfxResult<unsigned int> OK with returned program ID when successful; FAILURE otherwise.
- */
-GfxResult<unsigned int> OpenGlGfxController::getProgramId(uint index) {
-    // Boundary check index
-    if (index > programIdList_.size()) {
-        return GfxResult<unsigned int>(GfxApiResult::FAILURE, UINT_MAX);
+GfxResult<unsigned int> OpenGlGfxController::getProgramId(string programName) {
+    auto result = GFX_FAILURE(uint);
+    // Check if the program exists in the program ID map
+    auto pimit = programIdMap_.find(programName);
+    if (pimit != programIdMap_.end()) {
+        result = GfxResult<uint>(GfxApiResult::OK, pimit->second);
     }
-    return GfxResult<unsigned int>(GfxApiResult::OK, programIdList_[index]);
+    return result;
 }
 
 /**
@@ -162,8 +159,10 @@ GfxResult<unsigned int> OpenGlGfxController::getProgramId(uint index) {
  * @param fragmentShader Path to the fragmentShader to compile on the system
  * @return GfxResult<unsigned int> OK with the newly created programId; FAILURE otherwise.
  */
-GfxResult<unsigned int> OpenGlGfxController::loadShaders(string vertexShader, string fragmentShader) {
+GfxResult<unsigned int> OpenGlGfxController::loadShaders(string programName, string vertexShader, string fragmentShader) {
+    printf("Creaeting vertex shader id\n");
     unsigned int vertexShaderID = glCreateShader(GL_VERTEX_SHADER);
+    printf("Creaeting frag shader id\n");
     unsigned int fragmentShaderID = glCreateShader(GL_FRAGMENT_SHADER);
     int logLength;
     int success = GL_FALSE;
@@ -227,10 +226,10 @@ GfxResult<unsigned int> OpenGlGfxController::loadShaders(string vertexShader, st
     glDetachShader(programId, fragmentShaderID);
     glDeleteShader(vertexShaderID);
     glDeleteShader(fragmentShaderID);
-    // Add programId to programIdList
-    programIdList_.push_back(programId);
+    // Add programId to programIdMap
+    programIdMap_[programName] = programId;
 
-    printf("OpenGlGfxController::loadShaders: Created programId %d\n", programId);
+    printf("OpenGlGfxController::loadShaders: Created program %s -> programId %d\n", programName.c_str(), programId);
 
     return GfxResult<unsigned int>(GfxApiResult::OK, programId);
 }
@@ -713,14 +712,14 @@ OpenGlGfxController::~OpenGlGfxController() {
         glDeleteTextures(1, &textureId);
     }
     /* Delete Shader Programs */
-    for (auto programId : programIdList_) {
-        glDeleteProgram(programId);
+    for (auto programEntry : programIdMap_) {
+        glDeleteProgram(programEntry.second);
     }
 
     vaoList_.clear();
     vboList_.clear();
     textureIdList_.clear();
-    programIdList_.clear();
+    programIdMap_.clear();
 }
 
 void OpenGlGfxController::setBgColor(float r, float g, float b) {

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -31,6 +31,13 @@
 // Number of samples to use for anti-aliasing
 #define AASAMPLES 8
 
+/* Define constants for shader names */
+#define UIOBJECT_PROG_NAME "uiObject"
+#define SPRITEOBJECT_PROG_NAME "spriteObject"
+#define GAMEOBJECT_PROG_NAME "gameObject"
+#define TEXTOBJECT_PROG_NAME "textObject"
+#define COLLIDEROBJECT_PROG_NAME "colliderObject"
+
 extern double deltaTime;
 
 /*
@@ -85,10 +92,10 @@ class GameInstance {
     queue<SDL_Scancode> inputQueue_;
     bool audioInitialized_ = false;
 
-    void initWindow(const configData &config);
+    void initWindow();
     void initAudio();
     void initController();
-    void initApplication(vector<string> vertexPath, vector<string> fragmentPath);
+    void initApplication();
     /**
      * @brief Runs GFX requests on the main thread. This method is required when calling GfxController methods
      * from separate threads.
@@ -108,21 +115,20 @@ class GameInstance {
     void updateInput();
 
  public:
-    GameInstance(vector<string> vertShaders,
-        vector<string> fragShaders, GfxController *gfxController, AnimationController *animationController, int width,
+    GameInstance(GfxController *gfxController, AnimationController *animationController, int width,
         int height);
     ~GameInstance();
-    void startGame(const configData &config);
+    void init();
     GameObject *createGameObject(Polygon *characterModel, vec3 position, vec3 rotation, float scale,
         string objectName);
     CameraObject *createCamera(SceneObject *target, vec3 offset, float cameraAngle, float aspectRatio,
               float nearClipping, float farClipping);
     TextObject *createText(string message, vec3 position, float scale, string fontPath, float charSpacing,
-        int charPoint, uint programId, string objectName);
-    SpriteObject *createSprite(string spritePath, vec3 position, float scale, unsigned int programId,
+        int charPoint, string objectName);
+    SpriteObject *createSprite(string spritePath, vec3 position, float scale,
         ObjectAnchor anchor, string objectName);
     UiObject *createUi(string spritePath, vec3 position, float scale, float wScale, float hScale,
-        unsigned int programId, ObjectAnchor anchor, string objectName);
+        ObjectAnchor anchor, string objectName);
     int getWidth();
     int getHeight();
     vec3 getResolution();
@@ -187,4 +193,8 @@ class GameInstance {
      * GameInstance::waitForProgress so they can check if their predicate has been satisfied.
      */
     inline void signalProgress() { progressCv_.notify_all(); }
+    /**
+     * @brief Enables/disables use of Vsync.
+     */
+    void configureVsync(bool enable);
 };

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -17,7 +17,7 @@
 #include <map>
 #include <atomic>
 #include <queue>
-#include <condition_variable>
+#include <condition_variable> //NOLINT
 #include <common.hpp>
 #include <ModelImport.hpp>
 #include <GameObject.hpp>
@@ -30,13 +30,6 @@
 
 // Number of samples to use for anti-aliasing
 #define AASAMPLES 8
-
-/* Define constants for shader names */
-#define UIOBJECT_PROG_NAME "uiObject"
-#define SPRITEOBJECT_PROG_NAME "spriteObject"
-#define GAMEOBJECT_PROG_NAME "gameObject"
-#define TEXTOBJECT_PROG_NAME "textObject"
-#define COLLIDEROBJECT_PROG_NAME "colliderObject"
 
 extern double deltaTime;
 

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -8,7 +8,7 @@
  * @copyright Copyright (c) 2023
  *
  */
-#include <condition_variable>
+#include <condition_variable> //NOLINT
 #include <cstdio>
 #include <iostream>
 #include <string>

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -29,22 +29,21 @@
 
  (void) startGameInstance does not return any value.
  */
-GameInstance::GameInstance(vector<string> vertShaders,
-        vector<string> fragShaders, GfxController *gfxController, AnimationController *animationController,
+GameInstance::GameInstance(GfxController *gfxController, AnimationController *animationController,
         int width, int height) : gfxController_ { gfxController }, animationController_ { animationController },
-        vertShaders_ { vertShaders }, fragShaders_ { fragShaders }, width_ { width }, height_ { height },
+        width_ { width }, height_ { height },
         shutdown_(0) {
     luminance = 1.0f;  // Set default values
     directionalLight = vec3(-100, 100, 100);
     controllersConnected = 0;
+    init();
 }
 
-// Helper function for startup
-void GameInstance::startGame(const configData &config) {
-    initWindow(config);
+void GameInstance::init() {
+    initWindow();
     initAudio();
     initController();
-    initApplication(vertShaders_, fragShaders_);
+    initApplication();
     keystate = SDL_GetKeyboardState(NULL);
 }
 
@@ -353,8 +352,15 @@ GameObject *GameInstance::createGameObject(Polygon *characterModel, vec3 positio
     string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
     printf("GameInstance::createGameObject: Creating GameObject %zu\n", sceneObjects_.size());
+    auto gameObjProg = gfxController_->getProgramId(GAMEOBJECT_PROG_NAME);
+    if (!gameObjProg.isOk()) {
+        fprintf(stderr,
+            "GameInstance::createGameObject: Failed to create GameObject! '%s' program does not exist!\n",
+            GAMEOBJECT_PROG_NAME);
+        return nullptr;
+    }
     auto gameObject = std::make_shared<GameObject>(characterModel, position, rotation,
-        scale, objectName, ObjectType::GAME_OBJECT, gfxController_);
+        scale, gameObjProg.get(), objectName, ObjectType::GAME_OBJECT, gfxController_);
     gameObject.get()->setDirectionalLight(directionalLight);
     gameObject.get()->setLuminance(luminance);
     sceneObjects_.push_back(gameObject);
@@ -373,28 +379,49 @@ CameraObject *GameInstance::createCamera(SceneObject *target, vec3 offset, float
 }
 
 TextObject *GameInstance::createText(string message, vec3 position, float scale, string fontPath,
-    float charSpacing, int charPoint, uint programId, string objectName) {
+    float charSpacing, int charPoint, string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
     printf("GameInstance::createText: Creating TextObject %zu\n", sceneObjects_.size());
+    auto textProg = gfxController_->getProgramId(TEXTOBJECT_PROG_NAME);
+    if (!textProg.isOk()) {
+        fprintf(stderr,
+            "GameInstance::createText: Failed to create TextObject! '%s' program does not exist!\n",
+            TEXTOBJECT_PROG_NAME);
+        return nullptr;
+    }
     auto text = std::make_shared<TextObject>(message, position, scale, fontPath,
-        charSpacing, charPoint, programId, objectName, ObjectType::TEXT_OBJECT, gfxController_);
+        charSpacing, charPoint, textProg.get(), objectName, ObjectType::TEXT_OBJECT, gfxController_);
     sceneObjects_.push_back(text);
     return text.get();
 }
 
-SpriteObject *GameInstance::createSprite(string spritePath, vec3 position, float scale, unsigned int programId,
+SpriteObject *GameInstance::createSprite(string spritePath, vec3 position, float scale,
     ObjectAnchor anchor, string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
-    auto sprite = std::make_shared<SpriteObject>(spritePath, position, scale, programId, objectName,
+    auto spriteProg = gfxController_->getProgramId(SPRITEOBJECT_PROG_NAME);
+    if (!spriteProg.isOk()) {
+        fprintf(stderr,
+            "GameInstance::createSprite: Unable to create sprite! '%s' program does not exist!\n",
+            SPRITEOBJECT_PROG_NAME);
+        return nullptr;
+    }
+    auto sprite = std::make_shared<SpriteObject>(spritePath, position, scale, spriteProg.get(), objectName,
         ObjectType::SPRITE_OBJECT, anchor, gfxController_);
     sceneObjects_.push_back(sprite);
     return sprite.get();
 }
 
 UiObject *GameInstance::createUi(string spritePath, vec3 position, float scale, float wScale, float hScale,
-    unsigned int programId, ObjectAnchor anchor, string objectName) {
+    ObjectAnchor anchor, string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
-    auto ui = std::make_shared<UiObject>(spritePath, position, scale, wScale, hScale, programId, objectName,
+    auto uiProg = gfxController_->getProgramId("uiObject");
+    if (!uiProg.isOk()) {
+        fprintf(stderr,
+            "GameInstance::createUi: Failed to create UI object! '%s' program does not exist!\n",
+            UIOBJECT_PROG_NAME);
+        return nullptr;
+    }
+    auto ui = std::make_shared<UiObject>(spritePath, position, scale, wScale, hScale, uiProg.get(), objectName,
         ObjectType::UI_OBJECT, anchor, gfxController_);
     sceneObjects_.push_back(ui);
     return ui.get();
@@ -483,7 +510,7 @@ void GameInstance::setLuminance(float luminanceValue) {
 
  (void) initWindow does not return any values.
 */
-void GameInstance::initWindow(const configData &config) {
+void GameInstance::initWindow() {
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK);
     window = SDL_CreateWindow("Studious Engine Example", SDL_WINDOWPOS_CENTERED,
         SDL_WINDOWPOS_CENTERED, width_, height_,
@@ -503,14 +530,16 @@ void GameInstance::initWindow(const configData &config) {
 #endif
     mainContext = SDL_GL_CreateContext(window);
     if (!mainContext) exit(EXIT_FAILURE);
-
-    SDL_GL_SetSwapInterval(config.enableVsync);  // 0 - Disable VSYNC / 1 - Enable VSYNC
     renderer = SDL_GetRenderer(window);
 
     if (window == NULL) {
         cerr << "Error: Failed to create SDL window!\n";
         return;
     }
+}
+
+void GameInstance::configureVsync(bool enable) {
+    SDL_GL_SetSwapInterval(enable);  // 0 - Disable VSYNC / 1 - Enable VSYNC
 }
 
 /**
@@ -580,29 +609,8 @@ void GameInstance::initController() {
     return;
 }
 
-/*
- (void) initApplication grabs the shader files provided in the
- (vector<string>) vertexPath and (vector<string>) fragmentPath vectors and
- compiles and loads them into the current GameInstance.
-
- (void) initApplication does not return any values.
-*/
-void GameInstance::initApplication(vector<string> vertexPath, vector<string> fragmentPath) {
-    // Compile each of our shaders and assign them their own programId number
+void GameInstance::initApplication() {
     gfxController_->init();
-    for (uint i = 0; i < vertexPath.size(); i++) {
-        gfxController_->loadShaders(vertexPath[i].c_str(), fragmentPath[i].c_str());
-    }
-}
-
-/* [NOT IMPLEMENTED] [OLD WORK REMOVED DUE TO CHANGES]
- (void) basicCollision takes a (GameInstance *) gameInstance and performs a
- basic collision check on all of the active GameObjects in the scene. This
- method is still a WIP and does not really do anything at the moment.
-
- (void) basicCollision does not return any values.
-*/
-void GameInstance::basicCollision(GameInstance *gameInstance) {
 }
 
 int GameInstance::lockScene() {

--- a/src/main/engine/SceneObject/headers/ColliderObject.hpp
+++ b/src/main/engine/SceneObject/headers/ColliderObject.hpp
@@ -1,12 +1,12 @@
 /**
  * @file ColliderObject.hpp
  * @author Christian Galvez
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2024-02-15
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 
 #pragma once
@@ -27,7 +27,7 @@ class ColliderObject : public SceneObject {
     void updateCollider();
     void render() override;
     void update() override;
-    void createCollider(unsigned int programId);
+    void createCollider();
     int getCollision(ColliderObject *object, vec3 moving);
     float getColliderVertices(vector<float> vertices, int axis, bool (*test)(float a, float b));
     inline vec4 center() { return center_; }
@@ -47,4 +47,3 @@ class ColliderObject : public SceneObject {
     mat4 *pVpMatrix_;
     int mvpId_;
 };
-

--- a/src/main/engine/SceneObject/headers/GameObject.hpp
+++ b/src/main/engine/SceneObject/headers/GameObject.hpp
@@ -4,9 +4,9 @@
  * @brief GameObject is a SceneObject; can be rendered by a CameraObject
  * @version 0.1
  * @date 2023-07-28
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 
 #pragma once
@@ -22,7 +22,7 @@ class GameObject: public SceneObject {
  public:
     // Constructurs
     explicit GameObject(Polygon *characterModel, vec3 position, vec3 rotation, float scale,
-            string objectName, ObjectType type, GfxController *gfxController);
+            uint programId, string objectName, ObjectType type, GfxController *gfxController);
     explicit GameObject(GfxController *gfxController);
     ~GameObject() override;
 
@@ -41,7 +41,7 @@ class GameObject: public SceneObject {
     ColliderObject *getCollider();
 
     // Other methods
-    void createCollider(int programId);
+    void createCollider();
     void configureOpenGl();
 
     void render() override;

--- a/src/main/engine/SceneObject/headers/GameObject2D.hpp
+++ b/src/main/engine/SceneObject/headers/GameObject2D.hpp
@@ -34,7 +34,7 @@ class GameObject2D : public SceneObject, public TrackExt {
     void initializeTextureData();
     virtual void initializeShaderVars() = 0;
     void initializeVertexData();
-    void createCollider(int programId);
+    void createCollider();
     void setDimensions(int width, int height);
 
  protected:

--- a/src/main/engine/SceneObject/headers/SceneObject.hpp
+++ b/src/main/engine/SceneObject/headers/SceneObject.hpp
@@ -11,6 +11,13 @@
 #include <common.hpp>
 #include <GfxController.hpp>
 
+/* Define constants for shader names */
+#define UIOBJECT_PROG_NAME "uiObject"
+#define SPRITEOBJECT_PROG_NAME "spriteObject"
+#define GAMEOBJECT_PROG_NAME "gameObject"
+#define TEXTOBJECT_PROG_NAME "textObject"
+#define COLLIDEROBJECT_PROG_NAME "colliderObject"
+
 /// @todo Add SceneObject grouping for shared model changes
 enum ObjectType {
     UNDEFINED,

--- a/src/main/engine/SceneObject/src/GameObject.cpp
+++ b/src/main/engine/SceneObject/src/GameObject.cpp
@@ -158,10 +158,11 @@ ColliderObject *GameObject::getCollider(void) {
 void GameObject::createCollider() {
     printf("GameObject::createCollider: Creating collider for object %s\n", objectName.c_str());
     auto colliderName = objectName + "-Collider";
-    auto colliderProg = gfxController_->getProgramId("colliderObject");
-    if (!colliderProg.isOk())
-    {
-        fprintf(stderr, "GameObject::createCollider: Failed to create collider! 'colliderObject' shader not defined!\n");
+    auto colliderProg = gfxController_->getProgramId(COLLIDEROBJECT_PROG_NAME);
+    if (!colliderProg.isOk()) {
+        fprintf(stderr,
+            "GameObject::createCollider: Failed to create collider! '%s' shader not defined!\n",
+            COLLIDEROBJECT_PROG_NAME);
         return;
     }
     collider_ = std::make_shared<ColliderObject>(this->getModel(), colliderProg.get(), &translateMatrix_, &scaleMatrix_,

--- a/src/main/engine/SceneObject/src/GameObject2D.cpp
+++ b/src/main/engine/SceneObject/src/GameObject2D.cpp
@@ -88,13 +88,15 @@ void GameObject2D::update() {
 void GameObject2D::createCollider() {
     printf("GameObject2D::createCollider: Creating collider for object %s\n", objectName.c_str());
     auto colliderName = objectName + "-Collider";
-    auto colliderProg = gfxController_->getProgramId("colliderObject");
+    auto colliderProg = gfxController_->getProgramId(COLLIDEROBJECT_PROG_NAME);
     if (!colliderProg.isOk()) {
-        fprintf(stderr, "GameObject2D::createCollider: Failed to create collider! 'colliderObject' program does not exist!\n");
+        fprintf(stderr,
+            "GameObject2D::createCollider: Failed to create collider! '%s' program does not exist!\n",
+            COLLIDEROBJECT_PROG_NAME);
         return;
     }
-    collider_ = std::make_shared<ColliderObject>(vertTexData_, colliderProg.get(), &translateMatrix_, &scaleMatrix_, &vpMatrix_,
-        ObjectType::GAME_OBJECT, colliderName, gfxController_);
+    collider_ = std::make_shared<ColliderObject>(vertTexData_, colliderProg.get(), &translateMatrix_, &scaleMatrix_,
+        &vpMatrix_, ObjectType::GAME_OBJECT, colliderName, gfxController_);
 }
 
 /**

--- a/src/main/engine/SceneObject/src/GameObject2D.cpp
+++ b/src/main/engine/SceneObject/src/GameObject2D.cpp
@@ -4,9 +4,9 @@
  * @brief Implementation for GameObject2D
  * @version 0.1
  * @date 2023-07-28
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 #include <string>
 #include <cstdio>
@@ -59,7 +59,7 @@ void GameObject2D::initializeTextureData() {
  * @brief Updates the dimensions of the sprite. When using the splitGrid function, the image
  * itself will decrease in size, so we want to account for that. Run this to ensure the pixel
  * size remains the same after spliting.
- * 
+ *
  * @param width Width of the new sprite grid frame.
  * @param height Height of the new sprite grid frame.
  */
@@ -82,13 +82,18 @@ void GameObject2D::update() {
 
 /**
  * @brief Creates a collider for this game object
- * 
+ *
  * @param programId Program used to render the collider (collider shaders)
  */
-void GameObject2D::createCollider(int programId) {
+void GameObject2D::createCollider() {
     printf("GameObject2D::createCollider: Creating collider for object %s\n", objectName.c_str());
     auto colliderName = objectName + "-Collider";
-    collider_ = std::make_shared<ColliderObject>(vertTexData_, programId, &translateMatrix_, &scaleMatrix_, &vpMatrix_,
+    auto colliderProg = gfxController_->getProgramId("colliderObject");
+    if (!colliderProg.isOk()) {
+        fprintf(stderr, "GameObject2D::createCollider: Failed to create collider! 'colliderObject' program does not exist!\n");
+        return;
+    }
+    collider_ = std::make_shared<ColliderObject>(vertTexData_, colliderProg.get(), &translateMatrix_, &scaleMatrix_, &vpMatrix_,
         ObjectType::GAME_OBJECT, colliderName, gfxController_);
 }
 

--- a/src/main/utilities/headers/ModelImport.hpp
+++ b/src/main/utilities/headers/ModelImport.hpp
@@ -25,7 +25,7 @@ using std::ifstream;
 */
 class ModelImport {
  public:
-      explicit ModelImport(string, vector<string>, vector<int>, unsigned int);
+      explicit ModelImport(string, vector<string>, vector<int>);
       Polygon createPolygonFromFile();
       inline Polygon getPolygon() { return polygon_; }
       int processLine(string, int);
@@ -36,7 +36,6 @@ class ModelImport {
       vector<string> texturePath_;
       vector<int> texturePattern_;
       int textureCount_;  // Size of the texturePath vector
-      unsigned int programId_;
       vector<float> vertexFrame_;  // Unique vertex points
       vector<float> normalFrame_;  // Unique normal points
       vector<float> textureFrame_;  // Unique texture points

--- a/src/main/utilities/headers/Polygon.hpp
+++ b/src/main/utilities/headers/Polygon.hpp
@@ -16,9 +16,9 @@
 
 class Polygon {
  public:
-    Polygon(unsigned int pointCount, unsigned int programId, vector<float> vertices, vector<float> textures,
+    Polygon(unsigned int pointCount, vector<float> vertices, vector<float> textures,
         vector<float> normals);
-    Polygon(unsigned int pointCount, unsigned int programId, vector<float> vertices);
+    Polygon(unsigned int pointCount, vector<float> vertices);
     Polygon();
     void merge(const Polygon&);
     ~Polygon();
@@ -33,7 +33,6 @@ class Polygon {
     vector<unsigned int> pointCount;  // no. of distinct points in shape
     int numberOfObjects;  // Contains the number of objects in the model
     int textureUniformId;  // ID for finding texture sampler in OpenGL table
-    unsigned int programId;  // Used for storing programId of object's shader
 
     // Adding these in Polygon for now until we figure out material rendering
     vector<string> texturePath_;

--- a/src/main/utilities/src/ModelImport.cpp
+++ b/src/main/utilities/src/ModelImport.cpp
@@ -14,10 +14,8 @@
 #include <iostream>
 #include <ModelImport.hpp>
 
-ModelImport::ModelImport(string modelPath, vector<string> texturePath, vector<int> texturePattern,
-    unsigned int programId) :
-    modelPath_ { modelPath }, texturePath_ { texturePath }, texturePattern_ { texturePattern },
-    programId_ { programId } {
+ModelImport::ModelImport(string modelPath, vector<string> texturePath, vector<int> texturePattern) :
+    modelPath_ { modelPath }, texturePath_ { texturePath }, texturePattern_ { texturePattern } {
     cout << "ModelImport::ModelImport" << endl;
 }
 
@@ -43,7 +41,6 @@ Polygon ModelImport::createPolygonFromFile() {
     }
     // Create the final object in the polygon
     buildObject(currentObject - 1);
-    polygon_.programId = this->programId_;
     polygon_.texturePath_ = texturePath_;
     polygon_.texturePattern_ = texturePattern_;
     return polygon_;
@@ -154,7 +151,7 @@ int ModelImport::buildObject(int objectId) {
             }
         }
     }
-    auto newPolygon = Polygon(triCount, programId_, vertexVbo, textureVbo, normalVbo);
+    auto newPolygon = Polygon(triCount, vertexVbo, textureVbo, normalVbo);
     polygon_.merge(newPolygon);
     return 0;
 }

--- a/src/main/utilities/src/Polygon.cpp
+++ b/src/main/utilities/src/Polygon.cpp
@@ -26,8 +26,8 @@ static int polyCount;
  * @param textures Texture coordinates for the polygon
  * @param normals Normal vector for the polygon tri faces
  */
-Polygon::Polygon(unsigned int triCount, unsigned int programId, vector<float> vertices, vector<float> textures,
-    vector<float> normals) : Polygon(triCount, programId, vertices) {
+Polygon::Polygon(unsigned int triCount, vector<float> vertices, vector<float> textures,
+    vector<float> normals) : Polygon(triCount, vertices) {
     cout << "Polygon::Polygon: More complex constructor: polyCount[" << polyCount << "] -> [" << polyCount + 1 << "]"
         << endl;
 
@@ -45,8 +45,8 @@ Polygon::Polygon(unsigned int triCount, unsigned int programId, vector<float> ve
  * @param programId ProgramId used to identify the shader set associated with this polygon
  * @param vertices Vertex points for triangles making up the polygon
  */
-Polygon::Polygon(unsigned int pointCount, unsigned int programId, vector<float> vertices) :
-    pointCount { pointCount }, numberOfObjects { 1 }, textureUniformId { 0 }, programId { programId } {
+Polygon::Polygon(unsigned int pointCount, vector<float> vertices) :
+    pointCount { pointCount }, numberOfObjects { 1 }, textureUniformId { 0 } {
     cout << "Polygon::Polygon: Basic constructor: polyCount[" << polyCount << "] -> [" << polyCount + 1 << "]" << endl;
     ++polyCount;
 

--- a/src/main/utilities/test/src/ModelImportTests.cpp
+++ b/src/main/utilities/test/src/ModelImportTests.cpp
@@ -21,7 +21,7 @@ using std::endl;
 class ModelImportTest: public ::testing::Test {
  protected:
     void SetUp() override {
-        modelImport = new ModelImport("dummy", texturePathStage, texturePatternStage, 0);
+        modelImport = new ModelImport("dummy", texturePathStage, texturePatternStage);
     }
     void TearDown() override {
         delete modelImport;

--- a/src/main/utilities/test/src/PolygonTests.cpp
+++ b/src/main/utilities/test/src/PolygonTests.cpp
@@ -38,12 +38,11 @@ int main(int argc, char **argv) {
 
 Polygon createTestPolygon() {
     auto expectedPointCount = 123;
-    auto expectedProgramId = 1;
     vector<float> expectedVertices = { 0.333, 0.694, 0.777 };
     vector<float> expectedTextures = { 1.0, 0.1, 0.0 };
     vector<float> expectedNormals = { 0.123, 0.234, 0.345 };
 
-    auto polygon = Polygon(expectedPointCount, expectedProgramId, expectedVertices, expectedTextures, expectedNormals);
+    auto polygon = Polygon(expectedPointCount, expectedVertices, expectedTextures, expectedNormals);
 
     polygon.shapeBufferId[0] = 7;
     polygon.normalBufferId[0] = 8;
@@ -65,7 +64,6 @@ bool vectorEquals(vector<float> expectedVertices, vector<float> actualVertices) 
 TEST(PolygonConstructor, WhenConstructedWithData_ThenPolygonHasExpectedData) {
     // Preparation
     auto expectedPointCount = 123;
-    auto expectedProgramId = 1;
     auto expectedShapeBufferId = 0;
     auto expectedNormalBufferId = 0;
     auto expectedNumberOfObjects = 1;
@@ -74,11 +72,10 @@ TEST(PolygonConstructor, WhenConstructedWithData_ThenPolygonHasExpectedData) {
     vector<float> expectedNormals = { 0.123, 0.234, 0.345 };
 
     // Action
-    auto polygon = Polygon(expectedPointCount, expectedProgramId, expectedVertices, expectedTextures, expectedNormals);
+    auto polygon = Polygon(expectedPointCount, expectedVertices, expectedTextures, expectedNormals);
 
     // Validation
     EXPECT_EQ(expectedPointCount, polygon.pointCount[0]);
-    EXPECT_EQ(expectedProgramId, polygon.programId);
     EXPECT_TRUE(vectorEquals(expectedVertices, polygon.vertices[0]));
     EXPECT_TRUE(vectorEquals(expectedTextures, polygon.textureCoords[0]));
     EXPECT_TRUE(vectorEquals(expectedNormals, polygon.normalCoords[0]));
@@ -89,7 +86,6 @@ TEST(PolygonConstructor, WhenConstructedWithData_ThenPolygonHasExpectedData) {
 
 TEST(PolygonMerge, WhenTwoPolygonsMerged_ThenPolygonDataMergedOk) {
     // Preparation
-    auto expectedProgramId = 1;
     auto expectedNumberOfObjects = 2;
     auto expectedVectorSizesAfterMerge = 2;
     // Create two normal polygons to merge
@@ -104,9 +100,6 @@ TEST(PolygonMerge, WhenTwoPolygonsMerged_ThenPolygonDataMergedOk) {
     poly1.merge(poly2);
 
     // Validation
-    // Check that the programId is the same after merge
-    EXPECT_EQ(expectedProgramId, poly1.programId);
-
     // Check that the number of objects was incremented
     EXPECT_EQ(expectedNumberOfObjects, poly1.numberOfObjects);
 


### PR DESCRIPTION
Changes:
* Refactored the getProgramId code so it makes more sense. With this new design, programIds no longer need to be passed around everywhere, making it a lot easier to create scene objects.

# Changes

### Context
<!--- Give a brief description of your changes. -->
The current implementation of getProgramId requires the user to memorize which order they created GLSL programs, which is horrible. It required passing around magic numbers, which bloated certain parts of the code base. This new change uses a map<string, uint> to allow for fetching programIDs via friendly human-readable names. Error handling is also improved as an added benefit. :smile:
### Issues
<!--- List any relevant GitHub issues this PR is addressing here. -->
Did not file any.
### Considerations
<!--- If any major decisions, breaking changes, or redesigns were made, describe them here. Give a brief summary describing how you came to this conclusion. -->
This is just a nice to have, but it really makes the engine a lot easier to use.
## QA Checklist

- [x] I ran `cpplint --linelength=120 --recursive src/main/` and corrected any issues.
- [x] I added unit tests to relevant code.
- [x] I added/revised Doxygen documentation on new code.
- [x] I can compile using G++.
- [x] I am passing all unit tests. (`./setupBuild.sh -t`)
