### PR TITLE
HOTFIX - Occassional controller input crashing

### DIFF
--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -111,6 +111,7 @@ vec3 GameInstance::getDirectionalLight() {
 }
 
 const bool GameInstance::getControllerInput(SDL_GameControllerButton button) {
+    if (!controllersConnected) return false;
     // Checks if a button was pressed against all connected controllers
     if (gameControllers[0] == nullptr) {
         return false;


### PR DESCRIPTION
Changes:
* Fixed an issue where polling for controller input would occasionally crash the application when no controllers were connected.

# Changes

### Context
<!--- Give a brief description of your changes. -->

### Issues
<!--- List any relevant GitHub issues this PR is addressing here. -->

### Considerations
<!--- If any major decisions, breaking changes, or redesigns were made, describe them here. Give a brief summary describing how you came to this conclusion. -->

## QA Checklist

- [x] I ran `cpplint --linelength=120 --exclude=src/main/opengl --recursive src/main/` and corrected any issues.
- [x] I added unit tests to relevant code.
- [x] I added/revised Doxygen documentation on new code.
- [x] I can compile using G++.
- [x] I am passing all unit tests. (`./setupBuild.sh -t`)
- [x] I updated the basic template project if necessary (https://github.com/Weetsy/studious-template)
