### PR TITLE
Fix Constructor Mismatch Bug

### DIFF
--- a/src/main/engine/SceneObject/src/GameObject.cpp
+++ b/src/main/engine/SceneObject/src/GameObject.cpp
@@ -138,7 +138,7 @@ void GameObject::configureOpenGl() {
  * @brief GameObject destructor
  */
 GameObject::~GameObject() {
-    printf("GameObject::~GameObject\n");
+    printf("GameObject::~GameObject: destroying %s\n", objectName.c_str());
 }
 
 /**

--- a/src/main/utilities/headers/ModelImport.hpp
+++ b/src/main/utilities/headers/ModelImport.hpp
@@ -12,6 +12,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <utility>
 #include <Polygon.hpp>
 #include <winsup.hpp>
 #define DEFAULT_VECTOR_SIZE 256

--- a/src/main/utilities/headers/ModelImport.hpp
+++ b/src/main/utilities/headers/ModelImport.hpp
@@ -27,7 +27,8 @@ class ModelImport {
  public:
       explicit ModelImport(string, vector<string>, vector<int>);
       Polygon createPolygonFromFile();
-      inline Polygon getPolygon() { return polygon_; }
+      // Using the move constructor so we don't need to define a copy constructor
+      inline Polygon getPolygon() { return std::move(polygon_); }
       int processLine(string, int);
       int buildObject(int objectId);
       ~ModelImport();

--- a/src/main/utilities/headers/Polygon.hpp
+++ b/src/main/utilities/headers/Polygon.hpp
@@ -23,6 +23,14 @@ class Polygon {
     void merge(const Polygon&);
     ~Polygon();
 
+    /**
+     * @brief Move constructor definition for Polygon. This is only defined by us so we can
+     * increment the polyCount :)
+     * 
+     * @param other Polygon to move OUT from.
+     */
+    Polygon(Polygon&& other);
+
     vector<unsigned int> shapeBufferId;  // used for vertex buffer
     vector<unsigned int> textureCoordsId;  // used for texture coordinate buffer
     vector<unsigned int> textureId;  // ID for texture binding

--- a/src/main/utilities/src/ModelImport.cpp
+++ b/src/main/utilities/src/ModelImport.cpp
@@ -16,7 +16,7 @@
 
 ModelImport::ModelImport(string modelPath, vector<string> texturePath, vector<int> texturePattern) :
     modelPath_ { modelPath }, texturePath_ { texturePath }, texturePattern_ { texturePattern } {
-    cout << "ModelImport::ModelImport" << endl;
+    cout << "ModelImport::ModelImport: Importing " << modelPath << endl;
 }
 
 /**
@@ -43,7 +43,8 @@ Polygon ModelImport::createPolygonFromFile() {
     buildObject(currentObject - 1);
     polygon_.texturePath_ = texturePath_;
     polygon_.texturePattern_ = texturePattern_;
-    return polygon_;
+    // Call the move constructor to avoid unnecessary copies
+    return std::move(polygon_);
 }
 
 /**

--- a/src/main/utilities/src/Polygon.cpp
+++ b/src/main/utilities/src/Polygon.cpp
@@ -94,7 +94,8 @@ void Polygon::merge(const Polygon &polygon) {
 }
 
 Polygon::Polygon(Polygon&& other) {
-    cout << "Polygon::Polygon: Move constructor called: polyCount[" << polyCount << "] -> [" << polyCount + 1 << "]" << endl;
+    cout << "Polygon::Polygon: Move constructor called: polyCount[" <<
+        polyCount << "] -> [" << polyCount + 1 << "]" << endl;
     polyCount++;
     this->shapeBufferId = std::move(other.shapeBufferId);
     this->textureCoordsId = std::move(other.textureCoordsId);

--- a/src/main/utilities/src/Polygon.cpp
+++ b/src/main/utilities/src/Polygon.cpp
@@ -28,10 +28,8 @@ static int polyCount;
  */
 Polygon::Polygon(unsigned int triCount, vector<float> vertices, vector<float> textures,
     vector<float> normals) : Polygon(triCount, vertices) {
-    cout << "Polygon::Polygon: More complex constructor: polyCount[" << polyCount << "] -> [" << polyCount + 1 << "]"
+    cout << "Polygon::Polygon: More complex constructor: polyCount[" << polyCount << "]"
         << endl;
-
-    ++polyCount;
 
     /* Add textures*/
     this->textureCoords.push_back(textures);
@@ -76,6 +74,7 @@ Polygon::~Polygon() {
 }
 
 void Polygon::merge(const Polygon &polygon) {
+    cout << "Polygon::merge: Merging polygons!" << endl;
     // Copy over VBO objects from other polygon
     this->vertices.insert(this->vertices.end(), polygon.vertices.begin(), polygon.vertices.end());
     this->textureCoords.insert(this->textureCoords.end(), polygon.textureCoords.begin(), polygon.textureCoords.end());
@@ -92,4 +91,21 @@ void Polygon::merge(const Polygon &polygon) {
     this->pointCount.insert(this->pointCount.end(), polygon.pointCount.begin(), polygon.pointCount.end());
 
     this->numberOfObjects++;
+}
+
+Polygon::Polygon(Polygon&& other) {
+    cout << "Polygon::Polygon: Move constructor called: polyCount[" << polyCount << "] -> [" << polyCount + 1 << "]" << endl;
+    polyCount++;
+    this->shapeBufferId = std::move(other.shapeBufferId);
+    this->textureCoordsId = std::move(other.textureCoordsId);
+    this->textureId = std::move(other.textureId);
+    this->normalBufferId = std::move(other.normalBufferId);
+    this->vertices = std::move(other.vertices);
+    this->textureCoords = std::move(other.textureCoords);
+    this->normalCoords = std::move(other.normalCoords);
+    this->pointCount = std::move(other.pointCount);
+    this->numberOfObjects = other.numberOfObjects;
+    this->textureUniformId = other.textureUniformId;
+    this->texturePath_ = std::move(other.texturePath_);
+    this->texturePattern_ = std::move(other.texturePattern_);
 }


### PR DESCRIPTION
# Changes

### Context
<!--- Give a brief description of your changes. -->
Resolved the polygon constructor mismatch issue filed in #33. Basically, we were copying the ModelImport's internal polygon constructor, but the polyCount didn't increment from that. Instead of using a copy constructor, we now use a move constructor to avoid unnecessary copying. The default move constructor works fine, but I implemented a custom one to keep the polyCount score accurate. :+1: 
### Issues
<!--- List any relevant GitHub issues this PR is addressing here. -->
#33 
### Considerations
<!--- If any major decisions, breaking changes, or redesigns were made, describe them here. Give a brief summary describing how you came to this conclusion. -->

## QA Checklist

- [x] I ran `cpplint --linelength=120 --exclude=src/main/opengl --recursive src/main/` and corrected any issues.
- [x] I added unit tests to relevant code.
- [x] I added/revised Doxygen documentation on new code.
- [x] I can compile using G++.
- [x] I am passing all unit tests. (`./setupBuild.sh -t`)
- [x] I updated the basic template project if necessary (https://github.com/Weetsy/studious-template)
