### PR TITLE
Implemented Bleed-through KeyFrame Processing

### DIFF
--- a/src/main/engine/AnimationController/headers/AnimationController.hpp
+++ b/src/main/engine/AnimationController/headers/AnimationController.hpp
@@ -131,6 +131,7 @@ class AnimationController {
     int addKeyFrame(SceneObject *target, std::shared_ptr<KeyFrame> keyFrame);
     void addTrack(TrackExt *target, string trackName, vector<int> trackData, int fps, bool loop);
     void update();
+    UpdateData<float> updateKeyFrame(SceneObject *target, std::shared_ptr<KeyFrame> currentKf, float timeChange);
     int updatePosition(SceneObject *target, KeyFrame *keyFrame);
     int updateRotation(SceneObject *target, KeyFrame *keyFrame);
     int updateScale(SceneObject *target, KeyFrame *keyFrame);

--- a/src/main/engine/AnimationController/src/AnimationController.cpp
+++ b/src/main/engine/AnimationController/src/AnimationController.cpp
@@ -176,7 +176,8 @@ int AnimationController::addKeyFrame(SceneObject *target, std::shared_ptr<KeyFra
     return kfQueueSize;
 }
 
-UpdateData<float> AnimationController::updateKeyFrame(SceneObject *target, std::shared_ptr<KeyFrame> currentKf, float timeChange) {
+UpdateData<float> AnimationController::updateKeyFrame(SceneObject *target, std::shared_ptr<KeyFrame> currentKf,
+    float timeChange) {
     // If this is a brand new keyframe, set original values...
     if (currentKf->isNew) {
         currentKf->isNew = false;

--- a/src/main/engine/AnimationController/test/src/AnimationControllerTests.cpp
+++ b/src/main/engine/AnimationController/test/src/AnimationControllerTests.cpp
@@ -957,3 +957,41 @@ TEST_F(GivenAnAnimationControllerReady, WhenZeroTimeKeyFrameUpdates_ThenObjectUp
     /* Validation */
     ASSERT_EQ(expectedTransformation, obj.getScale());
 }
+
+/**
+ * @brief Tests animation keyframe bleed-through behavior. When a keyframe completes with excess time remaining, the
+ * next keyframe should process with the remaining time after that keyframe completes. This should result for
+ * smoother performance at lower framerates. 
+ * 
+ */
+TEST_F(GivenAnAnimationControllerReady, WhenKeyFrameTimeOverflows_ThenNextKeyFramesProcesses) {
+    /* Preparation */
+    TestObject obj(DUMMY_OBJ_NAME);
+    float originalScale = 1.0f;
+    float desiredScale_1 = 9.0f;
+    float desiredScale_2 = 15.0f;
+    float desiredScale_3 = 20.0f;
+    float targetTime_1 = 3.0f;
+    float targetTime_2 = 2.0f;
+    float targetTime_3 = 1.0f;
+    deltaTime = 6.0f;
+    float expectedTransformation = desiredScale_3;
+    auto keyFrame_1 = AnimationController::createKeyFrame(UPDATE_SCALE, targetTime_1);
+    auto keyFrame_2 = AnimationController::createKeyFrame(UPDATE_SCALE, targetTime_2);
+    auto keyFrame_3 = AnimationController::createKeyFrame(UPDATE_SCALE, targetTime_3);
+
+    obj.setScale(originalScale);
+    keyFrame_1.get()->scale.desired = desiredScale_1;
+    keyFrame_2.get()->scale.desired = desiredScale_2;
+    keyFrame_3.get()->scale.desired = desiredScale_3;
+    animationController_.addKeyFrame(&obj, keyFrame_1);
+    animationController_.addKeyFrame(&obj, keyFrame_2);
+    animationController_.addKeyFrame(&obj, keyFrame_3);
+
+    /* Action */
+    animationController_.update();
+
+    /* Validation */
+    ASSERT_EQ(expectedTransformation, obj.getScale());
+    ASSERT_TRUE(animationController_.getKeyFrameStore().empty());
+}


### PR DESCRIPTION
Changes:
* Implemented bleed through keyframe processing so that animation controller animations work more as intended. This helps with both lower end systems and higher end ones. Lower end systems will no longer see keyframe processing lag, and higher end systems should see more uniform transformations for short-live quick keyframe processing.

# Changes

### Context
<!--- Give a brief description of your changes. -->

### Issues
<!--- List any relevant GitHub issues this PR is addressing here. -->
#63 
### Considerations
<!--- If any major decisions, breaking changes, or redesigns were made, describe them here. Give a brief summary describing how you came to this conclusion. -->

## QA Checklist

- [x] I ran `cpplint --linelength=120 --exclude=src/main/opengl --recursive src/main/` and corrected any issues.
- [x] I added unit tests to relevant code.
- [x] I added/revised Doxygen documentation on new code.
- [x] I can compile using G++.
- [x] I am passing all unit tests. (`./setupBuild.sh -t`)
- [x] I updated the basic template project if necessary (https://github.com/Weetsy/studious-template)
