### PR TITLE
Wireframe runtime flag

### DIFF
--- a/src/main/engine/Misc/src/inputMonitor.cpp
+++ b/src/main/engine/Misc/src/inputMonitor.cpp
@@ -8,6 +8,7 @@
  * @copyright Copyright (c) 2023
  *
  */
+#include "ColliderObject.hpp"
 #include <iostream>
 #include <vector>
 #include <inputMonitor.hpp>
@@ -38,6 +39,7 @@ void rotateShape(void *gameInfoStruct, void *target) {
     float fallspeed = 0;
     bool trackMouse = false;
     bool uPressed = false;
+    bool lPressed = false;
     SDL_GameController *gameController1 = NULL;
     bool hasActiveController = false;
     if (numJoySticks < 1) {
@@ -324,6 +326,13 @@ void rotateShape(void *gameInfoStruct, void *target) {
             }
         } else if (!currentGame->getKeystateRaw()[SDL_SCANCODE_U] && uPressed) {
             uPressed = false;
+        }
+        if (currentGame->getKeystateRaw()[SDL_SCANCODE_L] && !lPressed) {
+            lPressed = true;
+            auto enableStatus = ColliderObject::getDrawCollider();
+            ColliderObject::setDrawCollider(!enableStatus);
+        } else if (!currentGame->getKeystateRaw()[SDL_SCANCODE_L] && lPressed) {
+            lPressed = false;
         }
         // Set character rotation based on joysticks
         // Left rotation

--- a/src/main/engine/Misc/src/inputMonitor.cpp
+++ b/src/main/engine/Misc/src/inputMonitor.cpp
@@ -8,10 +8,10 @@
  * @copyright Copyright (c) 2023
  *
  */
-#include "ColliderObject.hpp"
 #include <iostream>
 #include <vector>
 #include <inputMonitor.hpp>
+#include <ColliderObject.hpp>
 // Analog joystick dead zone
 const int JOYSTICK_DEAD_ZONE = 4000;
 #define PI 3.14159265

--- a/src/main/engine/SceneObject/headers/ColliderObject.hpp
+++ b/src/main/engine/SceneObject/headers/ColliderObject.hpp
@@ -33,6 +33,8 @@ class ColliderObject : public SceneObject {
     inline vec4 center() { return center_; }
     inline vec4 offset() { return offset_; }
     ~ColliderObject();
+    inline static void setDrawCollider(bool enable) { drawCollider_ = enable; }
+    inline static bool getDrawCollider() { return drawCollider_; }
 
  private:
     vec4 offset_;
@@ -46,4 +48,5 @@ class ColliderObject : public SceneObject {
     mat4 *pScaleMatrix_;
     mat4 *pVpMatrix_;
     int mvpId_;
+    inline static std::atomic<bool> drawCollider_;
 };

--- a/src/main/engine/SceneObject/src/ColliderObject.cpp
+++ b/src/main/engine/SceneObject/src/ColliderObject.cpp
@@ -104,7 +104,7 @@ int ColliderObject::getCollision(ColliderObject *object, vec3 moving) {
 void ColliderObject::update() {
     // Easy wireframe rendering is unsupported in OpenGL ES
 #ifndef GFX_EMBEDDED
-    render();
+    if (drawCollider_) render();
 #endif  // GFX_EMBEDDED
 }
 


### PR DESCRIPTION
# Changes

### Context
Added a runtime option to enable and disable wireframes from being rendered.

### Issues
#70

## QA Checklist

- [x] I ran `cpplint --linelength=120 --exclude=src/main/opengl --recursive src/main/` and corrected any issues.
- [x] I ran `r` and corrected any issues.
- [x] I added unit tests to relevant code. - N/A
- [ ] I added/revised Doxygen documentation on new code. - N/A
- [x] I can compile using G++.
- [x] I am passing all unit tests. (`./setupBuild.sh -t`)
- [x] I updated the basic template project if necessary (https://github.com/Weetsy/studious-template) - N/A