### PR TITLE
SceneObject constructor fix

### DIFF
--- a/src/main/engine/SceneObject/headers/SceneObject.hpp
+++ b/src/main/engine/SceneObject/headers/SceneObject.hpp
@@ -52,7 +52,8 @@ class SceneObject {
             position(position), rotation(rotation), objectName(objectName), scale_(scale), programId_(programId),
             type_ { type }, gfxController_ { gfxController } {}
     inline explicit SceneObject(ObjectType type, string objectName, GfxController *gfxController):
-        position { 0 }, rotation { 0 }, objectName { objectName }, scale_ { 0 }, type_ { type }, gfxController_ { gfxController } {}
+        position { 0 }, rotation { 0 }, objectName { objectName }, scale_ { 0 }, type_ { type },
+        gfxController_ { gfxController } {}
     virtual ~SceneObject();
     // Setter methods
     inline void setVpMatrix(mat4 vpMatrix) { vpMatrix_ = vpMatrix; }

--- a/src/main/engine/SceneObject/headers/SceneObject.hpp
+++ b/src/main/engine/SceneObject/headers/SceneObject.hpp
@@ -52,7 +52,7 @@ class SceneObject {
             position(position), rotation(rotation), objectName(objectName), scale_(scale), programId_(programId),
             type_ { type }, gfxController_ { gfxController } {}
     inline explicit SceneObject(ObjectType type, string objectName, GfxController *gfxController):
-        objectName { objectName }, type_ { type }, gfxController_ { gfxController } {}
+        position { 0 }, rotation { 0 }, objectName { objectName }, scale_ { 0 }, type_ { type }, gfxController_ { gfxController } {}
     virtual ~SceneObject();
     // Setter methods
     inline void setVpMatrix(mat4 vpMatrix) { vpMatrix_ = vpMatrix; }

--- a/src/main/engine/SceneObject/test/SceneObjectTests.cpp
+++ b/src/main/engine/SceneObject/test/SceneObjectTests.cpp
@@ -20,6 +20,14 @@ using std::endl;
 using std::cout;
 using std::set;
 
+template<typename T>
+void ASSERT_VEC_EQ(T actual, T expected) {
+    auto containerSize = sizeof(T) / sizeof(float);
+    for (uint i = 0; i < containerSize; ++i) {
+        ASSERT_FLOAT_EQ(actual[i], expected[i]);
+    }
+}
+
 /**
  * @brief Launches google test suite defined in file
  *
@@ -157,6 +165,25 @@ TEST_F(GivenASceneObject, WhenAddChild_ThenSceneObjectsConnected) {
     ASSERT_EQ(&object_, *parent.getChildren().begin());
     // Make sure the parent is set as the fixture object's parent
     ASSERT_EQ(&parent, object_.getParent());
+}
+
+/**
+ * @brief Ensures that SceneObject member variables are zeroed after initialization with basic constructor.
+ */
+TEST(GivenABasicSceneObject, WhenBasicConstructSceneObject_ThenValuesAreZeroed) {
+    /* Preparation */
+    vec3 expectedPosition = vec3(0);
+    vec3 expectedRotation = vec3(0);
+    float expectedScale_ = 0.0f;
+
+    /* Action */
+    TestObject object(PARENT_OBJECT_NAME);
+
+    /* Validation */
+    // Make sure certain member variables are initialized to zero
+    ASSERT_VEC_EQ(object.getPosition(), expectedPosition);
+    ASSERT_VEC_EQ(object.getRotation(), expectedRotation);
+    ASSERT_FLOAT_EQ(object.getScale(), expectedScale_);
 }
 
 /**


### PR DESCRIPTION
# Changes

### Context
Initialize position, rotation and scale_ values to 0 in SceneObject constructor

## QA Checklist

- [X] I ran `cpplint --linelength=120 --exclude=src/main/opengl --recursive src/main/` and corrected any issues.
- [X] I added unit tests to relevant code.
- [X] I added/revised Doxygen documentation on new code. - N/A
- [X] I can compile using G++.
- [X] I am passing all unit tests. (`./setupBuild.sh -t`)
- [X] I updated the basic template project if necessary (https://github.com/Weetsy/studious-template) - N/A
