### PR TITLE
Initial GameScene Implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(${PROJECT_NAME} SHARED
   src/main/utilities/src/ModelImport.cpp
   src/main/utilities/src/Polygon.cpp
   src/main/engine/Misc/src/GameInstance.cpp
+  src/main/engine/Misc/src/GameScene.cpp
   src/main/engine/SceneObject/src/SceneObject.cpp
   src/main/engine/SceneObject/src/GameObject.cpp
   src/main/engine/SceneObject/src/SpriteObject.cpp
@@ -304,6 +305,7 @@ install (FILES
   src/main/engine/GfxController/headers/GfxController.hpp
   src/main/engine/GfxController/headers/OpenGlGfxController.hpp
   src/main/engine/Misc/headers/GameInstance.hpp
+  src/main/engine/Misc/headers/GameScene.hpp
   src/main/engine/Misc/headers/Image.hpp
   src/main/engine/Misc/headers/physics.hpp
   src/main/misc/headers/config.hpp

--- a/examples/2dDemo/game.cpp
+++ b/examples/2dDemo/game.cpp
@@ -76,7 +76,7 @@ int runtime(GameInstance *currentGame) {
     SDL_SetRelativeMouseMode(SDL_FALSE);
     cout << "Creating camera.\n";
 
-    auto currentCamera = currentGame->createCamera(nullptr, vec3(0), 0.0, 16.0 / 9.0, 4.0, 90.0);
+    currentGame->createCamera(nullptr, vec3(0), 0.0, 16.0 / 9.0, 4.0, 90.0, "mainCamera");
     auto player = currentGame->createSprite("src/resources/images/JTIconNoBackground.png", vec3(0), 0.5,
         ObjectAnchor::BOTTOM_LEFT, "player");
     // Attach some other objects to the parent...
@@ -112,7 +112,7 @@ int runtime(GameInstance *currentGame) {
     animationController.get()->playTrack("all frames");
 
     // Create a new tile object and add it to the scene
-    auto tile = currentGame->createTileMap(
+    currentGame->createTileMap(
         {{ "floor_0", "src/resources/images/rock_texture.jpg" }},
         {{ 0, 0, "floor_0" },
         { 0, 1, "floor_0" },
@@ -122,20 +122,7 @@ int runtime(GameInstance *currentGame) {
         0.1f,
         ObjectAnchor::BOTTOM_LEFT,
         "test-tile");
-    // Add objects to camera
-    vector<SceneObject *> targets = {
-        obstacle,
-        player,
-        tile,
-        playerAccessory,
-        playerAccessoryToo
-    };
 
-    // Add all objects to active camera
-    for (auto it = targets.begin(); it != targets.end(); ++it) {
-        cout << "Adding to camera: " << (*it)->getObjectName() << endl;
-        currentCamera->addSceneObject(*it);
-    }
     /*
      End Scene Loading
      */

--- a/examples/3dDemoScene/game.cpp
+++ b/examples/3dDemoScene/game.cpp
@@ -71,6 +71,7 @@ int main() {
     auto config = StudiousConfig("src/resources/config.txt");
 
     GameInstance currentGame(config);
+    currentGame.createGameScene("3d-demo-scene");
 
     // Load shader programs
     for (auto program : programs) {
@@ -116,7 +117,7 @@ int runtime(GameInstance *currentGame) {
         texturePatternStage)
         .createPolygonFromFile();
 
-    auto mapObject = currentGame->createGameObject(mapPoly,
+    currentGame->createGameObject(mapPoly,
         vec3(-0.006f, -0.019f, 0.0f), vec3(0.0f, 0.0f, 0.0f), 0.009500f, "map");
 
     cout << "Creating Player\n";
@@ -180,7 +181,7 @@ int runtime(GameInstance *currentGame) {
     wolfRef = wolfObject;
 
     // Configure some in-game text objects
-    auto engineText = currentGame->createText(
+    currentGame->createText(
         "Studious Engine 2025",                 // Message
         vec3(25.0f, 25.0f, 0.0f),               // Position
         1.0f,                                   // Scale
@@ -218,14 +219,14 @@ int runtime(GameInstance *currentGame) {
         48,
         "fps-text");
 
-    auto testSprite = currentGame->createSprite(
+    currentGame->createSprite(
         "src/resources/images/JTIconNoBackground.png",
         vec3(1250.0f, 50.0f, 0.0f),
         0.1f,
         ObjectAnchor::CENTER,
         "test-sprite");
 
-    auto testUi = currentGame->createUi(
+    currentGame->createUi(
         "src/resources/images/Message Bubble UI.png",   // image path
         vec3(80.0f, 160.0f, 0.0f),                     // Position
         0.5f,                                           // Scale
@@ -233,7 +234,7 @@ int runtime(GameInstance *currentGame) {
         0.0f,                                           // Height
         ObjectAnchor::CENTER,                           // Anchor
         "uiBubble");                                    // UI Bubble
-    auto testText = currentGame->createText(
+    currentGame->createText(
         "Textbox Example",
         vec3(40.0f, 155.0f, 0.0f),
         0.6f,
@@ -246,7 +247,7 @@ int runtime(GameInstance *currentGame) {
     fps_counter->setMessage("FPS: 0");
 
     auto currentCamera = currentGame->createCamera(playerRef,
-        vec3(5.140022f, 1.349999f, 2.309998f), 3.14159 / 5.0f, 16.0f / 9.0f, 4.0f, 90.0f);
+        vec3(5.140022f, 1.349999f, 2.309998f), 3.14159 / 5.0f, 16.0f / 9.0f, 4.0f, 90.0f, "mainCamera");
     playerRef->setRotation(vec3(0, 0, 0));
     cout << "currentGameObject tag is " << playerRef->getObjectName()
         << '\n';
@@ -254,30 +255,6 @@ int runtime(GameInstance *currentGame) {
     playerRef->setPosition(vec3(-0.005f, 0.01f, 0.0f));
     playerRef->setRotation(vec3(0.0f, 180.0f, 0.0f));
     playerRef->setScale(0.0062f);
-
-    // Add objects to camera
-    vector<SceneObject *> targets = {
-        mapObject,
-        playerRef,
-        wolfObject,
-        engineText,
-        contactText,
-        fpsText,
-        pressUText,
-        testSprite,
-        testUi,
-        testText,
-        companion,
-        companion2,
-        companion3,
-        companion4
-    };
-
-    // Add all objects to active camera
-    for (auto it = targets.begin(); it != targets.end(); ++it) {
-        cout << "Adding to camera: " << (*it)->getObjectName() << endl;
-        currentCamera->addSceneObject(*it);
-    }
 
     currentGameInfo.isDone = &isDone;
     currentGameInfo.gameCamera = currentCamera;

--- a/examples/3dDemoScene/inputMonitor.cpp
+++ b/examples/3dDemoScene/inputMonitor.cpp
@@ -39,7 +39,6 @@ void rotateShape(void *gameInfoStruct, void *target) {
     /// @todo Refactor and remove reinterpret_casts if re-using this code
     gameInfo *currentGameInfo = reinterpret_cast<gameInfo *>(gameInfoStruct);
     GameInstance *currentGame = currentGameInfo->currentGame;
-    CameraObject *renderer = currentGameInfo->gameCamera;
     AnimationController *ac = animationController.get();
     PhysicsController *pc = physicsController.get();
     GameObject *character = reinterpret_cast<GameObject *>(target);  // GameObject to rotate
@@ -368,7 +367,6 @@ void rotateShape(void *gameInfoStruct, void *target) {
                 };
                 auto bkf = AnimationController::createKeyFrameCb(UPDATE_NONE, delcb, expireTime);
                 ac->addKeyFrame(bulletObj, bkf);
-                renderer->addSceneObject(bulletObj);
                 PhysicsParams params(true, false, 0.0f, 1.0f);
                 pc->addSceneObject(bulletObj, params);
                 // Convert angles[1] to a direction????

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -31,6 +31,7 @@
 #include <config.hpp>
 #include <physics.hpp>
 #include <AnimationController.hpp>
+#include <GameScene.hpp>
 
 // Number of samples to use for anti-aliasing
 #define AASAMPLES 8
@@ -79,8 +80,8 @@ class GameInstance {
     SDL_Renderer *renderer;
     SDL_Event event;
     SDL_GLContext mainContext;
-    vector<std::shared_ptr<SceneObject>> sceneObjects_;
     vector<std::shared_ptr<CameraObject>> cameras_;
+    std::shared_ptr<CameraObject> activeCamera_;
     vector<string> vertShaders_;
     vector<string> fragShaders_;
     vector<string> texturePathStage_;
@@ -89,7 +90,6 @@ class GameInstance {
     map<string, int> activeChannels_;
     SDL_GameController *gameControllers[2];
     controllerReadout controllerInfo[2];
-    vec3 directionalLight_;
     float luminance;
     int width_, height_;
     int vsync_;
@@ -106,6 +106,8 @@ class GameInstance {
     queue<std::function<void(void)>> protectedGfxReqs_;
     queue<GameInput> inputQueue_;
     bool audioInitialized_ = false;
+    std::shared_ptr<GameScene> activeScene_;
+    map<string, std::shared_ptr<GameScene>> gameScenes_;
 
     void initWindow();
     void initAudio();
@@ -151,6 +153,9 @@ class GameInstance {
      */
     void resetController();
 
+    void addSceneObject(std::shared_ptr<SceneObject> sceneObject);
+    std::shared_ptr<GameScene> getGameScene_(string sceneName);
+
  public:
     explicit GameInstance(const StudiousConfig &config);
     ~GameInstance();
@@ -158,7 +163,7 @@ class GameInstance {
     GameObject *createGameObject(std::shared_ptr<Polygon> characterModel, vec3 position, vec3 rotation, float scale,
         string objectName);
     CameraObject *createCamera(SceneObject *target, vec3 offset, float cameraAngle, float aspectRatio,
-              float nearClipping, float farClipping);
+              float nearClipping, float farClipping, string cameraName);
     TextObject *createText(string message, vec3 position, float scale, string fontPath, float charSpacing,
         int charPoint, string objectName);
     SpriteObject *createSprite(string spritePath, vec3 position, float scale,
@@ -262,4 +267,9 @@ class GameInstance {
      */
     void configureVsync(bool enable);
     void processConfig(const StudiousConfig &config);
+    void createGameScene(string sceneName);
+    void loadGameSceneFromFile(string path);
+    inline std::shared_ptr<GameScene> getActiveScene() { return activeScene_; }
+    void setActiveScene(string sceneName);
+    std::shared_ptr<GameScene> getGameScene(string sceneName);
 };

--- a/src/main/engine/Misc/headers/GameScene.hpp
+++ b/src/main/engine/Misc/headers/GameScene.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <memory.h>
+#include <map>
+#include <SceneObject.hpp>
+#include <CameraObject.hpp>
+/**
+ * Note for me: A GameScene is essentially a collection of SceneObjects that define a scene. The CameraObject will be
+ * independent of a Scene, but should be passed to the GameScene for rendering. For now, there should only
+ * be one active camera at a time ever. The camera is managed by the GameInstance, and applies transformations
+ * to objects in a GameScene.
+ *
+ * Should the object creation methods be moved over to the scene itself? Maybe not, since we probably don't want to
+ * keep pointers for each individual scene around... Probably best to modify them in the GameInstance class to just
+ * create an inject scene objects into a game scene.
+ *
+ * How should we handle rendering? Right now it's handled by the camera. I think we should have an update() function
+ * inside of the GameScene itself, and the current camera calls it with its VP matrix passed as an arg. That should
+ * make scene switching really easy.
+ *
+ * Will probably need to call update() on the camera first, then update on the GameScene.
+ */
+class GameScene {
+ public:
+    explicit inline GameScene(std::string sceneName) : sceneName_ { sceneName } {}
+
+    void addSceneObject(std::shared_ptr<SceneObject> sceneObject);
+    void removeSceneObject(std::string objectName);
+    std::shared_ptr<SceneObject> getSceneObject(std::string objectName);
+
+    void update(CameraObject *camera);
+
+    void loadGameScene(std::string *path);
+    void saveGameScene(std::string *path);
+
+    // MISC
+    void setDirectionalLight(vec3 directionalLight);
+    inline vec3 getDirectionalLight() { return directionalLight_; }
+    inline string getSceneName() const { return sceneName_; }
+ private:
+    void resetRenderPriorityMap();
+    std::string sceneName_;
+    std::map<std::string, std::shared_ptr<SceneObject>> sceneObjects_;
+    // Render priority to list of scene objects
+    map<uint, vector<std::shared_ptr<SceneObject>>> renderPriorityMap_;
+    vec3 directionalLight_ = vec3(-100, 100, 100);
+    std::mutex sceneLock_;
+};

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -14,6 +14,7 @@
 #include <condition_variable> //NOLINT
 #include <cstdio>
 #include <iostream>
+#include <mutex>
 #include <string>
 #include <vector>
 #include <memory>
@@ -71,7 +72,6 @@ map<Uint8, GameInput> hatInputMap = {
  */
 GameInstance::GameInstance(const StudiousConfig &config): shutdown_(0) {
     luminance = 1.0f;  // Set default values
-    directionalLight_ = vec3(-100, 100, 100);
     controllersConnected = 0;
     processConfig(config);
     init();
@@ -103,14 +103,6 @@ int GameInstance::getHeight() {
 
 vec3 GameInstance::getResolution() {
     return vec3(static_cast<float>(width_), static_cast<float>(height_), 0.0f);
-}
-
-/*
- (vec3) getDirectionalLight returns the current location of the directionalLight
- in the scene.
- */
-vec3 GameInstance::getDirectionalLight() {
-    return directionalLight_;
 }
 
 bool GameInstance::getControllerInput(SDL_GameControllerButton button) const {
@@ -359,6 +351,9 @@ int GameInstance::updateObjects() {
         camera->setResolution(this->getResolution());
         camera->update();
     }
+    // Update the current scene
+    if (activeScene_.get() && activeCamera_.get())
+        activeScene_.get()->update(activeCamera_.get());
     return 0;
 }
 
@@ -456,10 +451,18 @@ bool GameInstance::waitForInput(GameInput input) {
     return curInput == input;
 }
 
+void GameInstance::addSceneObject(std::shared_ptr<SceneObject> sceneObject) {
+    if (!activeScene_.get()) {
+        fprintf(stderr, "GameInstance::addSceneObject: No active scene! Ignoring game object %s\n",
+            sceneObject.get()->getObjectName().c_str());
+        return;
+    }
+    activeScene_.get()->addSceneObject(sceneObject);
+}
+
 GameObject *GameInstance::createGameObject(std::shared_ptr<Polygon> characterModel, vec3 position, vec3 rotation,
     float scale, string objectName) {
-    std::unique_lock<std::mutex> lock(sceneLock_);
-    printf("GameInstance::createGameObject: Creating GameObject %zu\n", sceneObjects_.size());
+    printf("GameInstance::createGameObject: Creating GameObject %s\n", objectName.c_str());
     auto gameObjProg = gfxController_->getProgramId(GAMEOBJECT_PROG_NAME);
     if (!gameObjProg.isOk()) {
         fprintf(stderr,
@@ -469,28 +472,33 @@ GameObject *GameInstance::createGameObject(std::shared_ptr<Polygon> characterMod
     }
     auto gameObject = std::make_shared<GameObject>(characterModel, position, rotation,
         scale, gameObjProg.get(), objectName, ObjectType::GAME_OBJECT, gfxController_);
-    gameObject.get()->setDirectionalLight(directionalLight_);
+    if (activeScene_.get()) {
+        auto dirLight = activeScene_.get()->getDirectionalLight();
+        gameObject.get()->setDirectionalLight(dirLight);
+    }
     gameObject.get()->setLuminance(luminance);
     gameObject.get()->setRenderPriority(RENDER_PRIOR_LOW);
-    sceneObjects_.push_back(gameObject);
+    addSceneObject(gameObject);
     return gameObject.get();
 }
 
 CameraObject *GameInstance::createCamera(SceneObject *target, vec3 offset, float cameraAngle, float aspectRatio,
-              float nearClipping, float farClipping) {
-    std::unique_lock<std::mutex> lock(sceneLock_);
-    printf("GameInstance::createCamera: Creating CameraObject %zu\n", sceneObjects_.size());
-    auto cameraName = "Camera" + std::to_string(sceneObjects_.size());
+              float nearClipping, float farClipping, string cameraName) {
+    printf("GameInstance::createCamera: Creating CameraObject %s\n", cameraName.c_str());
     auto gameCamera = std::make_shared<CameraObject>(target, offset, cameraAngle,
         aspectRatio, nearClipping, farClipping, ObjectType::CAMERA_OBJECT, cameraName, gfxController_);
+    if (!activeCamera_.get()) {
+        printf("GameInstance::createCamera: No active cameras detected. Setting camera %s as new active camera.\n",
+                cameraName.c_str());
+        activeCamera_ = gameCamera;
+    }
     cameras_.push_back(gameCamera);
     return gameCamera.get();
 }
 
 TextObject *GameInstance::createText(string message, vec3 position, float scale, string fontPath,
     float charSpacing, int charPoint, string objectName) {
-    std::unique_lock<std::mutex> lock(sceneLock_);
-    printf("GameInstance::createText: Creating TextObject %zu\n", sceneObjects_.size());
+    printf("GameInstance::createText: Creating TextObject %s\n", objectName.c_str());
     auto textProg = gfxController_->getProgramId(TEXTOBJECT_PROG_NAME);
     if (!textProg.isOk()) {
         fprintf(stderr,
@@ -501,13 +509,12 @@ TextObject *GameInstance::createText(string message, vec3 position, float scale,
     auto text = std::make_shared<TextObject>(message, position, scale, fontPath,
         charSpacing, charPoint, textProg.get(), objectName, ObjectType::TEXT_OBJECT, gfxController_);
     text.get()->setRenderPriority(RENDER_PRIOR_HIGH);
-    sceneObjects_.push_back(text);
+    addSceneObject(text);
     return text.get();
 }
 
 SpriteObject *GameInstance::createSprite(string spritePath, vec3 position, float scale,
     ObjectAnchor anchor, string objectName) {
-    std::unique_lock<std::mutex> lock(sceneLock_);
     auto spriteProg = gfxController_->getProgramId(SPRITEOBJECT_PROG_NAME);
     if (!spriteProg.isOk()) {
         fprintf(stderr,
@@ -518,13 +525,12 @@ SpriteObject *GameInstance::createSprite(string spritePath, vec3 position, float
     auto sprite = std::make_shared<SpriteObject>(spritePath, position, scale, spriteProg.get(), objectName,
         ObjectType::SPRITE_OBJECT, anchor, gfxController_);
     sprite.get()->setRenderPriority(RENDER_PRIOR_LOW);
-    sceneObjects_.push_back(sprite);
+    addSceneObject(sprite);
     return sprite.get();
 }
 
 UiObject *GameInstance::createUi(string spritePath, vec3 position, float scale, float wScale, float hScale,
     ObjectAnchor anchor, string objectName) {
-    std::unique_lock<std::mutex> lock(sceneLock_);
     auto uiProg = gfxController_->getProgramId(UIOBJECT_PROG_NAME);
     if (!uiProg.isOk()) {
         fprintf(stderr,
@@ -535,14 +541,12 @@ UiObject *GameInstance::createUi(string spritePath, vec3 position, float scale, 
     auto ui = std::make_shared<UiObject>(spritePath, position, scale, wScale, hScale, uiProg.get(), objectName,
         ObjectType::UI_OBJECT, anchor, gfxController_);
     ui.get()->setRenderPriority(RENDER_PRIOR_MEDIUM);
-    sceneObjects_.push_back(ui);
+    addSceneObject(ui);
     return ui.get();
 }
 
 TileObject *GameInstance::createTileMap(map<string, string> textures, vector<TileData> mapData,
     vec3 position, float scale, ObjectAnchor anchor, string objectName) {
-    std::unique_lock<std::mutex> lock(sceneLock_);
-    printf("GameInstance::createTileMap: Creating TextObject %zu\n", sceneObjects_.size());
     auto tileProg = gfxController_->getProgramId(TILEOBJECT_PROG_NAME);
     if (!tileProg.isOk()) {
         fprintf(stderr,
@@ -553,16 +557,20 @@ TileObject *GameInstance::createTileMap(map<string, string> textures, vector<Til
     auto tile = std::make_shared<TileObject>(textures, mapData, position, vec3(0.0f), scale, ObjectType::TILE_OBJECT,
     tileProg.get(), objectName, anchor, gfxController_);
     tile.get()->setRenderPriority(RENDER_PRIOR_LOWEST);
-    sceneObjects_.push_back(tile);
+    addSceneObject(tile);
     return tile.get();
 }
 
 SceneObject *GameInstance::getSceneObject(string objectName) {
-    std::unique_lock<std::mutex> lock(sceneLock_);
     SceneObject *result = nullptr;
-    for (auto it = sceneObjects_.begin(); it != sceneObjects_.end(); ++it) {
-        if ((*it).get()->getObjectName().compare(objectName) == 0) result = (*it).get();
+    // Attempt to find the scene object in the current scene
+    if (!activeScene_.get()) {
+        fprintf(stderr,
+            "GameInstance::getSceneObject: Unable to find %s, no active scene!",
+            objectName.c_str());
+        return result;
     }
+    result = activeScene_.get()->getSceneObject(objectName).get();
     return result;
 }
 
@@ -581,21 +589,10 @@ int GameInstance::removeSceneObject(string objectName) {
     std::unique_lock<std::mutex> lock(sceneLock_);
     animationController_->removeSceneObject(objectName);
     physicsController_->removeSceneObject(objectName);
-    // Search for the object by name
-    auto objectIt = std::find_if(sceneObjects_.begin(), sceneObjects_.end(),
-        [&objectName](std::shared_ptr<SceneObject> obj) {
-            return obj->getObjectName().compare(objectName) == 0;
-        });
-
-    if (objectIt == sceneObjects_.end()) {
-        fprintf(stderr, "GameInstance::removeSceneObject: Not found (%s)\n",
-            objectName.c_str());
-        return -1;
+    if (activeScene_.get()) {
+        // Time will tell if we need to remove object from ALL scenes or just active...
+        activeScene_.get()->removeSceneObject(objectName);
     }
-    for (auto camera : cameras_) {
-        camera->removeSceneObject(objectName);
-    }
-    sceneObjects_.erase(objectIt);
     return 0;
 }
 
@@ -637,15 +634,8 @@ void GameInstance::setLuminance(float luminanceValue) {
 }
 
 void GameInstance::setDirectionalLight(vec3 directionalLight) {
-    std::unique_lock<std::mutex> sceneLock(sceneLock_);
-    directionalLight_ = directionalLight;
-
-    // Send new directional light to 3D gameobjects
-    for (auto obj : sceneObjects_) {
-        if (obj->type() == GAME_OBJECT) {
-            GameObject *cObj = static_cast<GameObject *>(obj.get());
-            cObj->setDirectionalLight(directionalLight_);
-        }
+    if (activeScene_.get()) {
+        activeScene_.get()->setDirectionalLight(directionalLight);
     }
 }
 
@@ -847,4 +837,61 @@ void GameInstance::processConfig(const StudiousConfig &config) {
     gfxController_ = gfxController.get();
     physicsController_ = physicsController.get();
     animationController_ = animationController.get();
+}
+
+std::shared_ptr<GameScene> GameInstance::getGameScene(string sceneName) {
+    std::unique_lock<std::mutex> scopeLock(sceneLock_);
+    return getGameScene_(sceneName);
+}
+
+std::shared_ptr<GameScene> GameInstance::getGameScene_(string sceneName) {
+    std::shared_ptr<GameScene> result;
+    auto gsit = gameScenes_.find(sceneName);
+    if (gsit != gameScenes_.end()) {
+        result = gsit->second;
+    } else {
+        fprintf(stderr, "GameInstance::getGameScene: %s does not exist!\n",
+            sceneName.c_str());
+    }
+    return result;
+}
+
+vec3 GameInstance::getDirectionalLight() {
+    vec3 res = vec3(0);
+    if (activeScene_.get())
+        res = activeScene_.get()->getDirectionalLight();
+    return res;
+}
+
+void GameInstance::createGameScene(string sceneName) {
+    auto gameScene = getGameScene(sceneName);
+    if (gameScene.get()) {
+        printf("GameInstance::createGameScene: Scene %s will be clobbered\n",
+            sceneName.c_str());
+    }
+    gameScenes_[sceneName] = std::make_shared<GameScene>(sceneName);
+    // Auto set active scene if none currently set
+    if (!activeScene_.get())
+        activeScene_ = gameScenes_.at(sceneName);
+}
+
+void loadGameSceneFromFile(string path) {
+    printf("Unsupported %s\n", path.c_str());
+}
+
+void GameInstance::setActiveScene(string sceneName) {
+    std::unique_lock<std::mutex> scopeLock(sceneLock_);
+    if (activeScene_.get() &&
+        activeScene_.get()->getSceneName().compare(sceneName) == 0) {
+        printf("GameInstance::setActiveScene: %s is already the active scene!\n",
+            sceneName.c_str());
+    }
+    auto gameScene = getGameScene(sceneName);
+    if (!gameScene.get()) {
+        fprintf(stderr,
+            "GameInstance::setActiveScene: %s not found! Not updating scene.\n",
+            sceneName.c_str());
+    } else {
+        activeScene_ = gameScene;
+    }
 }

--- a/src/main/engine/Misc/src/GameScene.cpp
+++ b/src/main/engine/Misc/src/GameScene.cpp
@@ -1,0 +1,99 @@
+#include "SceneObject.hpp"
+#include <GameScene.hpp>
+#include <cassert>
+
+void GameScene::addSceneObject(std::shared_ptr<SceneObject> sceneObject) {
+    std::unique_lock<std::mutex> scopeLock(sceneLock_);
+    if (!sceneObject.get()) {
+        fprintf(stderr,
+            "GameScene::addSceneObject: Cannot add invalid scene object!\n");
+        return;
+    }
+    assert(!sceneObject->getObjectName().empty());
+    sceneObjects_[sceneObject->getObjectName()] = sceneObject;
+    renderPriorityMap_[sceneObject->getRenderPriority()].push_back(sceneObject);
+}
+
+void GameScene::removeSceneObject(std::string objectName) {
+    std::unique_lock<std::mutex> scopeLock(sceneLock_);
+    auto soit = sceneObjects_.find(objectName);
+    if (soit != sceneObjects_.end()) {
+        sceneObjects_.erase(soit);
+        resetRenderPriorityMap();
+    } else {
+        fprintf(stderr,
+            "GameScene::removeSceneObject: %s not found\n",
+            objectName.c_str());
+    }
+}
+
+void GameScene::update(CameraObject *camera) {
+    std::unique_lock<std::mutex> scopeLock(sceneLock_);
+    if (camera == nullptr) {
+        fprintf(stderr, "GameScene::update: Camera missing!\n");
+        return;
+    }
+    auto resolution = camera->getResolution();
+    auto perspectiveMat = camera->getPerspective();
+    auto orthoMat = camera->getOrthographic();
+    auto orthoMatBase = camera->getOrthographicBase();
+    for (auto &obj : renderPriorityMap_) {
+        // Send the current screen res to each object
+        /// @todo Maybe use a global variable for resolution?
+        auto objList = obj.second;
+        for (auto objPtr : objList) {
+            objPtr->setResolution(resolution);
+            // Check if the object is ORTHO or PERSPECTIVE
+            switch (objPtr->type()) {
+                case GAME_OBJECT:
+                    objPtr->setVpMatrix(perspectiveMat);
+                    break;
+                case UI_OBJECT:
+                    /* Do not apply view to UI */
+                    objPtr->setVpMatrix(orthoMatBase);
+                    break;
+                case SPRITE_OBJECT:
+                case TEXT_OBJECT:
+                case TILE_OBJECT:
+                    objPtr->setVpMatrix(orthoMat);
+                    break;
+                default:
+                    printf("CameraObject::update: Ignoring object [%s] type [%d]\n", objPtr->getObjectName().c_str(),
+                        objPtr->type());
+                    break;
+            }
+            // Render the object -> the map iterator will sort keys automatically
+            objPtr->update();
+        }
+    }
+}
+
+void GameScene::resetRenderPriorityMap() {
+    renderPriorityMap_.clear();
+    for (auto obj : sceneObjects_) {
+        renderPriorityMap_[obj.second.get()->getRenderPriority()].push_back(obj.second);
+    }
+}
+
+std::shared_ptr<SceneObject> GameScene::getSceneObject(std::string objectName) {
+    std::unique_lock<std::mutex> scopeLock(sceneLock_);
+    std::shared_ptr<SceneObject> result;
+    auto soit = sceneObjects_.find(objectName);
+    if (soit != sceneObjects_.end()) {
+        result = soit->second;
+    }
+    return result;
+}
+
+void GameScene::setDirectionalLight(vec3 directionalLight) {
+    std::unique_lock<std::mutex> scopeLock(sceneLock_);
+    directionalLight_ = directionalLight;
+    // Send new directional light to 3D gameobjects
+    for (auto obj : sceneObjects_) {
+        // Make this a light ext eventually...
+        if (obj.second.get()->type() == GAME_OBJECT) {
+            GameObject *cObj = static_cast<GameObject *>(obj.second.get());
+            cObj->setDirectionalLight(directionalLight);
+        }
+    }
+}

--- a/src/main/engine/SceneObject/headers/CameraObject.hpp
+++ b/src/main/engine/SceneObject/headers/CameraObject.hpp
@@ -32,22 +32,17 @@ class CameraObject : public SceneObject {
     inline vec3 getOffset() { return offset_; }
     inline SceneObject *getTarget() { return target_; }
     inline float getAspectRatio() { return aspectRatio_; }
-    inline vector<SceneObject *> getSceneObjects() const { return sceneObjects_; }
+    inline mat4 getPerspective() const { return vpMatrixPerspective_; }
+    inline mat4 getOrthographic() const { return vpMatrixOrthographic_; }
+    inline mat4 getOrthographicBase() const { return orthographicMatrix_; }
 
     // Camera Specific Methods
     void render() override;
     void update() override;
-    void addSceneObject(SceneObject *gameObject);
-    void removeSceneObject(string objectName);
-    void resetRenderPriorityMap();
-    inline void clearSceneObjects() { sceneObjects_.clear(); sceneObjectsOrdered_.clear(); }
 
  private:
     void resetRenderPriorityMap_();
     SceneObject *target_;
-    vector<SceneObject *> sceneObjects_;
-    // Render priority to list of scene objects
-    map<uint, vector<SceneObject *>> sceneObjectsOrdered_;
     vec3 offset_;
     vec3 initialTargetPos_;
     mat4 vpMatrixPerspective_;

--- a/src/main/engine/SceneObject/headers/SceneObject.hpp
+++ b/src/main/engine/SceneObject/headers/SceneObject.hpp
@@ -128,4 +128,5 @@ class SceneObject {
     std::set<SceneObject *> children_;
 
     mutex objectLock_;
+    bool visible_ = true;
 };

--- a/src/resources/config.txt
+++ b/src/resources/config.txt
@@ -1,5 +1,5 @@
 resX=1280
 resY=720
 enableVsync=1
-physThreads=10
+physThreads=1
 gfx=OpenGL


### PR DESCRIPTION
Changes:
* Move rendering logic out of CameraObject and into GameScene.
* No longer required to add scene objects to the camera - we can just create them and they will automatically get bound to the scene.

# Changes

### Context
<!--- Give a brief description of your changes. -->

### Issues
<!--- List any relevant GitHub issues this PR is addressing here. -->

### Considerations
<!--- If any major decisions, breaking changes, or redesigns were made, describe them here. Give a brief summary describing how you came to this conclusion. -->

## QA Checklist

- [ ] I ran `cpplint --linelength=120 --exclude=src/main/opengl --recursive src/main/` and corrected any issues.
- [ ] I added unit tests to relevant code.
- [ ] I can compile using G++.
- [ ] I am passing all unit tests. (`./setupBuild.sh -t`)
- [ ] I updated the basic template project if necessary (https://github.com/Weetsy/studious-template)
