### PR TITLE
Break InputController to New Class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(${PROJECT_NAME} SHARED
   src/main/engine/GfxController/src/DummyGfxController.cpp
   src/main/engine/GfxController/src/OpenGlGfxController.cpp
   src/main/engine/AnimationController/src/AnimationController.cpp
+  src/main/engine/Misc/src/InputController.cpp
   src/main/engine/Misc/src/DeltaTime.cpp
   src/main/engine/Misc/src/Image.cpp
   src/main/misc/src/config.cpp

--- a/examples/2dDemo/game.cpp
+++ b/examples/2dDemo/game.cpp
@@ -18,6 +18,7 @@
 #include <cstdio>
 #include <OpenGlGfxController.hpp>
 #include <AnimationController.hpp>
+#include <InputController.hpp>
 
 // Lists of embedded/core shaders
 #ifndef GFX_EMBEDDED
@@ -43,6 +44,7 @@ vector<ProgramData> programs = {
 extern std::unique_ptr<GfxController> gfxController;
 extern std::unique_ptr<AnimationController> animationController;
 extern std::unique_ptr<PhysicsController> physicsController;
+extern std::unique_ptr <InputController> inputController;
 
 int runtime(GameInstance *currentGame);
 int mainLoop(GameInstance *currentGame);
@@ -155,21 +157,21 @@ int mainLoop(GameInstance *currentGame) {
         offset = vec3(0);
         /// @todo Move these calls to a separate thread...
         begin = SDL_GetPerformanceCounter();
-        if (currentGame->pollInput(GameInput::QUIT)) currentGame->shutdown();
+        if (inputController->pollInput(GameInput::QUIT)) currentGame->shutdown();
         error = currentGame->update();
         if (error) {
             return error;
         }
         end = SDL_GetPerformanceCounter();
-        if (currentGame->pollInput(GameInput::NORTH)) offset += vec3(0, speed, 0);
-        if (currentGame->pollInput(GameInput::SOUTH)) offset -= vec3(0, speed, 0);
-        if (currentGame->pollInput(GameInput::EAST)) offset += vec3(speed, 0, 0);
-        if (currentGame->pollInput(GameInput::WEST)) offset -= vec3(speed, 0, 0);
-        if (currentGame->pollInput(GameInput::X) && !eDown) {
+        if (inputController->pollInput(GameInput::NORTH)) offset += vec3(0, speed, 0);
+        if (inputController->pollInput(GameInput::SOUTH)) offset -= vec3(0, speed, 0);
+        if (inputController->pollInput(GameInput::EAST)) offset += vec3(speed, 0, 0);
+        if (inputController->pollInput(GameInput::WEST)) offset -= vec3(speed, 0, 0);
+        if (inputController->pollInput(GameInput::X) && !eDown) {
             printf("E pressed!\n");
             eDown = true;
             animationController.get()->pauseTrack("obstacle");
-        } else if (!currentGame->pollInput(GameInput::X) && eDown) {
+        } else if (!inputController->pollInput(GameInput::X) && eDown) {
             printf("E released!\n");
             eDown = false;
             animationController.get()->playTrack("one to four");

--- a/examples/3dDemoScene/game.cpp
+++ b/examples/3dDemoScene/game.cpp
@@ -5,9 +5,9 @@
  *       game engine. These two basic game files will generate a basic scene when the
  *       engine is compiled and ran.
  * @version 0.1
- * @date 2023-07-28
+ * @date 2025
  *
- * @copyright Copyright (c) 2023
+ * @copyright Copyright (c) 2025
  *
  */
 #include "GameInstance.hpp"
@@ -63,6 +63,7 @@ GameObject *wolfRef, *playerRef;  // Used for collision testing
 extern std::unique_ptr<GfxController> gfxController;
 extern std::unique_ptr<AnimationController> animationController;
 extern std::unique_ptr<PhysicsController> physicsController;
+extern std::unique_ptr<InputController> inputController;
 
 int runtime(GameInstance *currentGame);
 int mainLoop(gameInfo *gamein);
@@ -263,6 +264,7 @@ int runtime(GameInstance *currentGame) {
     currentGameInfo.isDone = &isDone;
     currentGameInfo.gameCamera = currentCamera;
     currentGameInfo.currentGame = currentGame;
+    currentGameInfo.gameInput = &**&inputController;
     /*
      End Scene Loading
      */
@@ -293,7 +295,7 @@ int mainLoop(gameInfo* gamein) {
     vector<double> times;
     while (!currentGame->isShutDown()) {
         begin = SDL_GetPerformanceCounter();
-        if (currentGame->pollInput(GameInput::QUIT)) currentGame->shutdown();
+        if (inputController->pollInput(GameInput::QUIT)) currentGame->shutdown();
         error = currentGame->update();
         if (error) {
             return error;

--- a/examples/3dDemoScene/game.hpp
+++ b/examples/3dDemoScene/game.hpp
@@ -26,4 +26,5 @@ typedef struct gameInfo {
     bool *isDone;
     CameraObject *gameCamera;
     GameInstance *currentGame;
+    InputController *gameInput;
 } gameInfo;

--- a/examples/3dDemoScene/inputMonitor.cpp
+++ b/examples/3dDemoScene/inputMonitor.cpp
@@ -39,6 +39,7 @@ void rotateShape(void *gameInfoStruct, void *target) {
     /// @todo Refactor and remove reinterpret_casts if re-using this code
     gameInfo *currentGameInfo = reinterpret_cast<gameInfo *>(gameInfoStruct);
     GameInstance *currentGame = currentGameInfo->currentGame;
+    InputController* gameInput = currentGameInfo->gameInput;
     AnimationController *ac = animationController.get();
     PhysicsController *pc = physicsController.get();
     GameObject *character = reinterpret_cast<GameObject *>(target);  // GameObject to rotate
@@ -93,12 +94,12 @@ void rotateShape(void *gameInfoStruct, void *target) {
         // SDL_WarpMouseInWindow(currentGame->getWindow(), currentGame->getWidth() / 2, currentGame->getHeight() / 2);
         usleep(9000);
         // Begin Camera Controls
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_KP_5]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_KP_5]) {
             cameraOffset[0] = 5.140022f;  // Set values back to inital values
             cameraOffset[1] = 1.349999f;
             cameraOffset[2] = 2.309998f;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_KP_2] ||
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_KP_2] ||
             (mouseY < 0 && trackMouse) || controllerRightStateY < -JOYSTICK_DEAD_ZONE) {
             float modifier = 1.0f;
             if (mouseY < 0) {
@@ -119,7 +120,7 @@ void rotateShape(void *gameInfoStruct, void *target) {
             cameraOffset[2] /= distFinish[0];
             cameraOffset[0] /= distFinish[1];
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_KP_8] ||
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_KP_8] ||
             (mouseY > 0 && trackMouse) || controllerRightStateY > JOYSTICK_DEAD_ZONE) {
             // cameraOffset[1] += offsetSpeed;
             float modifier = 1.0f;
@@ -141,13 +142,13 @@ void rotateShape(void *gameInfoStruct, void *target) {
             cameraOffset[2] /= distFinish[0];
             cameraOffset[0] /= distFinish[1];
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_KP_4]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_KP_4]) {
             cameraOffset[0] -= offsetSpeed;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_KP_6]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_KP_6]) {
             cameraOffset[0] += offsetSpeed;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_KP_7] ||
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_KP_7] ||
             (mouseX < 0 && trackMouse) || controllerRightStateX < -JOYSTICK_DEAD_ZONE) {
             // Rotate the camera about the y axis
             float distHold = cameraOffset[0] * cameraOffset[0] + cameraOffset[2] * cameraOffset[2];
@@ -177,7 +178,7 @@ void rotateShape(void *gameInfoStruct, void *target) {
             cameraOffset[0] /= distFinish;
             cameraOffset[2] /= distFinish;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_KP_9] ||
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_KP_9] ||
             (mouseX > 0 && trackMouse) || controllerRightStateX > JOYSTICK_DEAD_ZONE) {
             float distHold = cameraOffset[0] * cameraOffset[0] + cameraOffset[2] * cameraOffset[2];
             float multiplier = 1.0f;
@@ -206,35 +207,35 @@ void rotateShape(void *gameInfoStruct, void *target) {
             cameraOffset[0] /= distFinish;
             cameraOffset[2] /= distFinish;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_KP_MINUS]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_KP_MINUS]) {
             cameraOffset[0] *= 1.01f;  // Zoom out
             cameraOffset[1] *= 1.01f;
             cameraOffset[2] *= 1.01f;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_KP_PLUS]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_KP_PLUS]) {
             cameraOffset[0] *= 0.99f;  // Zoom in
             cameraOffset[1] *= 0.99f;
             cameraOffset[2] *= 0.99f;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_F]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_F]) {
             angles[0] -= rotateSpeed;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_R]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_R]) {
             angles[0] += rotateSpeed;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_G]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_G]) {
             angles[1] -= rotateSpeed;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_T]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_T]) {
             angles[1] += rotateSpeed;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_H]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_H]) {
             angles[2] -= rotateSpeed;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_Y]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_Y]) {
             angles[2] += rotateSpeed;
         }
-        if (currentGame->pollInput(GameInput::SOUTH) || controllerLeftStateY < -JOYSTICK_DEAD_ZONE) {
+        if (gameInput->pollInput(GameInput::SOUTH) || controllerLeftStateY < -JOYSTICK_DEAD_ZONE) {
             angles[1] = -1.0f * angle - 90.0f;
             float xSpeed = sin((angles[1]) * (PI / 180)) * speed;
             float ySpeed = cos((angles[1]) * (PI / 180)) * speed;
@@ -245,7 +246,7 @@ void rotateShape(void *gameInfoStruct, void *target) {
             pos[0] += (xSpeed / 300.0f) * multiplier;
             pos[2] += (ySpeed / 300.0f) * multiplier;
         }
-        if (currentGame->pollInput(GameInput::NORTH) || controllerLeftStateY > JOYSTICK_DEAD_ZONE) {
+        if (gameInput->pollInput(GameInput::NORTH) || controllerLeftStateY > JOYSTICK_DEAD_ZONE) {
             angles[1] = -1.0f * angle + 90.0f;
             float xSpeed = sin(angles[1] * (PI / 180)) * speed;
             float ySpeed = cos(angles[1] * (PI / 180)) * speed;
@@ -255,18 +256,18 @@ void rotateShape(void *gameInfoStruct, void *target) {
             pos[0] += (xSpeed / 300.0f) * multiplier;
             pos[2] += (ySpeed / 300.0f) * multiplier;
         }
-        if (currentGame->pollInput(GameInput::A) && pos[1] == 0) {
+        if (gameInput->pollInput(GameInput::A) && pos[1] == 0) {
             fallspeed = -0.003f;
             // pos[1] += 0.05f;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_E]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_E]) {
             fallspeed = 0;
             pos[1] += speed;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_Q]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_Q]) {
             pos[1] -= speed;
         }
-        if (currentGame->pollInput(GameInput::WEST) || controllerLeftStateX > JOYSTICK_DEAD_ZONE) {
+        if (gameInput->pollInput(GameInput::WEST) || controllerLeftStateX > JOYSTICK_DEAD_ZONE) {
             angles[1] = -1.0f * angle + 180.0f;
             float xSpeed = sin((angles[1]) * (PI / 180)) * speed;
             float ySpeed = cos((angles[1]) * (PI / 180)) * speed;
@@ -277,7 +278,7 @@ void rotateShape(void *gameInfoStruct, void *target) {
             pos[0] += (xSpeed / 300.0f) * multiplier;
             pos[2] += (ySpeed / 300.0f) * multiplier;
         }
-        if (currentGame->pollInput(GameInput::EAST) || controllerLeftStateX < -JOYSTICK_DEAD_ZONE) {
+        if (gameInput->pollInput(GameInput::EAST) || controllerLeftStateX < -JOYSTICK_DEAD_ZONE) {
             angles[1] = -1.0f * angle;
             float xSpeed = sin((angles[1]) * (PI / 180)) * speed;
             float ySpeed = cos((angles[1]) * (PI / 180)) * speed;
@@ -288,25 +289,25 @@ void rotateShape(void *gameInfoStruct, void *target) {
             pos[0] += (xSpeed / 300.0f) * multiplier;
             pos[2] += (ySpeed / 300.0f) * multiplier;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_C]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_C]) {
             currentLuminance += 0.01f;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_V]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_V]) {
             currentLuminance -= 0.01f;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_P]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_P]) {
             currentGame->changeWindowMode(SDL_WINDOW_FULLSCREEN_DESKTOP);
-        } else if (currentGame->getKeystateRaw()[SDL_SCANCODE_O]) {
+        } else if (gameInput->getKeystateRaw()[SDL_SCANCODE_O]) {
             currentGame->changeWindowMode(SDL_WINDOW_FULLSCREEN);
-        } else if (currentGame->getKeystateRaw()[SDL_SCANCODE_I]) {
+        } else if (gameInput->getKeystateRaw()[SDL_SCANCODE_I]) {
             currentGame->changeWindowMode(0);
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_9]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_9]) {
             // Rotate on X+ axis
             auto currentRotation = currentGameInfo->gameCamera->getRotation();
             currentRotation[0] += 1.0f;
             currentGameInfo->gameCamera->setRotation(currentRotation);
-        } else if (currentGame->getKeystateRaw()[SDL_SCANCODE_0]) {
+        } else if (gameInput->getKeystateRaw()[SDL_SCANCODE_0]) {
             // Rotate on X- axis
             auto currentRotation = currentGameInfo->gameCamera->getRotation();
             currentRotation[0] -= 1.0f;
@@ -314,19 +315,19 @@ void rotateShape(void *gameInfoStruct, void *target) {
         }
 
         // Move the directional light
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_7]) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_7]) {
             // Shift light origin diagonal pos
             auto dirLight = currentGame->getDirectionalLight();
             dirLight += vec3(1.0f);
             currentGame->setDirectionalLight(dirLight);
-        } else if (currentGame->getKeystateRaw()[SDL_SCANCODE_8]) {
+        } else if (gameInput->getKeystateRaw()[SDL_SCANCODE_8]) {
             // Shift light origin diagonal neg
             auto dirLight = currentGame->getDirectionalLight();
             dirLight -= vec3(1.0f);
             currentGame->setDirectionalLight(dirLight);
         }
 
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_U] && !uPressed) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_U] && !uPressed) {
             uPressed = true;
             if (SDL_GetRelativeMouseMode() == SDL_FALSE) {
                 SDL_SetRelativeMouseMode(SDL_TRUE);
@@ -335,10 +336,10 @@ void rotateShape(void *gameInfoStruct, void *target) {
                 SDL_SetRelativeMouseMode(SDL_FALSE);
                 trackMouse = false;
             }
-        } else if (!currentGame->getKeystateRaw()[SDL_SCANCODE_U] && uPressed) {
+        } else if (!gameInput->getKeystateRaw()[SDL_SCANCODE_U] && uPressed) {
             uPressed = false;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_6] && !sixPressed) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_6] && !sixPressed) {
             sixPressed = true;
             if (currentGame->getActiveScene().get()->getSceneName().compare("3d-demo-scene") == 0) {
                 currentGame->setActiveScene("alternate-3d-scene");
@@ -349,17 +350,17 @@ void rotateShape(void *gameInfoStruct, void *target) {
                 auto altPlayer = currentGame->getSceneObject("player");
                 currentGameInfo->gameCamera->setTarget(altPlayer);
             }
-        } else if (!currentGame->getKeystateRaw()[SDL_SCANCODE_6] && sixPressed) {
+        } else if (!gameInput->getKeystateRaw()[SDL_SCANCODE_6] && sixPressed) {
             sixPressed = false;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_L] && !lPressed) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_L] && !lPressed) {
             lPressed = true;
             auto enableStatus = ColliderObject::getDrawCollider();
             ColliderObject::setDrawCollider(!enableStatus);
-        } else if (!currentGame->getKeystateRaw()[SDL_SCANCODE_L] && lPressed) {
+        } else if (!gameInput->getKeystateRaw()[SDL_SCANCODE_L] && lPressed) {
             lPressed = false;
         }
-        if (currentGame->getKeystateRaw()[SDL_SCANCODE_BACKSPACE] && !delPressed) {
+        if (gameInput->getKeystateRaw()[SDL_SCANCODE_BACKSPACE] && !delPressed) {
             delPressed = true;
             static int bulletCount;
             // Instantiate a bullet and shoot it
@@ -392,7 +393,7 @@ void rotateShape(void *gameInfoStruct, void *target) {
                 printf("Detected rot %f %f %f\n", charAngle.x, charAngle.y, charAngle.z);
                 pc->applyForce(bulletName, vec3(anglex * magnitude, 0.0f, anglez * magnitude));
             }
-        } else if (!currentGame->getKeystateRaw()[SDL_SCANCODE_BACKSPACE] && delPressed) {
+        } else if (!gameInput->getKeystateRaw()[SDL_SCANCODE_BACKSPACE] && delPressed) {
             delPressed = false;
         }
         // Set character rotation based on joysticks

--- a/src/main/engine/Misc/headers/GameInstance.hpp
+++ b/src/main/engine/Misc/headers/GameInstance.hpp
@@ -32,35 +32,12 @@
 #include <physics.hpp>
 #include <AnimationController.hpp>
 #include <GameScene.hpp>
+#include <InputController.hpp>
 
 // Number of samples to use for anti-aliasing
 #define AASAMPLES 8
 
 extern double deltaTime;
-
-/*
- controllerReadout is used for getting input from a controller. This struct
- will be used in conjunction with SDL_GameControllerGetAxis to get input from
- the left controller stick.
-*/
-typedef struct controllerReadout {
-    Sint16 leftAxis;
-} controllerReadout;
-
-enum class GameInput {
-    NONE,
-    QUIT,
-    NORTH,
-    SOUTH,
-    EAST,
-    WEST,
-    A,
-    B,
-    X,
-    Y,
-    R,
-    L
-};
 
 /*
  The GameInstance class is the class that holds all of the information about the
@@ -72,7 +49,6 @@ enum class GameInput {
 */
 class GameInstance {
  private:
-    const Uint8 *keystate;
     GfxController *gfxController_;
     AnimationController *animationController_;
     PhysicsController *physicsController_;
@@ -88,19 +64,16 @@ class GameInstance {
     vector<string> texturePath_;
     map<string, Mix_Chunk *> loadedSounds_;
     map<string, int> activeChannels_;
-    SDL_GameController *gameControllers[2];
-    controllerReadout controllerInfo[2];
     float luminance;
     int width_, height_;
     int vsync_;
-    int audioID, controllersConnected = 0;
+    int audioID;
     std::atomic<int> shutdown_;
     mutex sceneLock_;
     mutex soundLock_;
     mutex requestLock_;
     mutex inputLock_;
     mutex progressLock_;
-    mutex controllerLock_;
     std::condition_variable inputCv_;
     std::condition_variable progressCv_;
     queue<std::function<void(void)>> protectedGfxReqs_;
@@ -111,7 +84,6 @@ class GameInstance {
 
     void initWindow();
     void initAudio();
-    void initController();
     void initApplication();
     /**
      * @brief Runs GFX requests on the main thread. This method is required when calling GfxController methods
@@ -130,28 +102,6 @@ class GameInstance {
      * @brief Polls for new input events and pushes them to the input queue.
      */
     void updateInput();
-    /**
-     * @brief Converts a raw SDL scancode value to a GameInput value. @see keyboardInputMap in the GameInstance.cpp
-     * source file to see the complete mapping.
-     * @return GameInput mapped to the raw input, or GameInput::NONE if undefined input received.
-     */
-    GameInput scancodeToInput(SDL_Scancode scancode);
-    /**
-     * @brief Converts a raw SDL button input to the raw input's button map. @see controllerInputMap in the
-     * GameInstance.cpp source file.
-     * @return GameInput mapping to the raw button input. Returns GameInput::NONE if an input is received that is
-     * not defined in the controllerInputMap.
-     */
-    GameInput buttonToInput(SDL_GameControllerButton button);
-    /**
-     * @brief Converts a raw SDL hat input to a GameInput.
-     * @return GameInput mapping to the raw hat value. Returns GameInput::NONE is mapping not found.
-     */
-    GameInput hatToInput(Uint8 hatValue);
-    /**
-     * @brief Closes all active controllers and performs some cleanup.
-     */
-    void resetController();
 
     bool addSceneObject(std::shared_ptr<SceneObject> sceneObject);
     std::shared_ptr<GameScene> getGameScene_(string sceneName);
@@ -182,32 +132,6 @@ class GameInstance {
      * @return True when the request is fulfilled, otherwise return false.
      */
     bool protectedGfxRequest(std::function<void(void)> req);
-    /**
-     * @brief Can be used to check raw SDL scancode values. This has the same behavior as the previous
-     * getKeystate function did.
-     * @return Uint8 array that can be indexed using SDL_Scancode enumerated values.
-     */
-    const Uint8 *getKeystateRaw();
-    /**
-     * @brief Shorthand way to check if a keyboard button has been pressed.
-     * @param scancode - The SDL_Scancode enum value to check for input state.
-     * @return true if the button described in scancode is pressed down, false otherwise.
-     */
-    bool getKeyboardInput(SDL_Scancode scancode) const;
-    /**
-     * @brief Check if a SDL_GameControllerButton has been pressed.
-     * @param button - The button to poll the input state of. Described by SDL_GameControllerButton.
-     * @return true if the button is pressed down, false otherwise.
-     */
-    bool getControllerInput(SDL_GameControllerButton button) const;
-    /**
-     * @brief Polls for a specific input across keyboard and controller input devices.
-     * @param input - The input to check for.
-     * @return true if the GameInput is being pressed by a keyboard or controller. False otherwise.
-     */
-    bool pollInput(GameInput input);
-    controllerReadout *getControllers(int controllerIndex);
-    int getControllersConnected();
     int playSound(string sfxName, bool loop, int volume);
     int loadSound(string sfxName, string sfxPath);
     int changeVolume(string sfxName, int volume);

--- a/src/main/engine/Misc/headers/InputController.hpp
+++ b/src/main/engine/Misc/headers/InputController.hpp
@@ -1,0 +1,114 @@
+/**
+ * @file inputController.hpp
+ * @author Christian Galvez
+ * @author Alec Jackson
+ * @brief Helper class to monitor input
+ * @version 0.1
+ * @date 2025
+ *
+ * @copyright Copyright (c) 2025
+ *
+ */
+
+#pragma once
+
+#include <mutex> //NOLINT
+
+enum class GameInput {
+    NONE,
+    QUIT,
+    NORTH,
+    SOUTH,
+    EAST,
+    WEST,
+    A,
+    B,
+    X,
+    Y,
+    R,
+    L
+};
+
+/*
+ controllerReadout is used for getting input from a controller. This struct
+ will be used in conjunction with SDL_GameControllerGetAxis to get input from
+ the left controller stick.
+*/
+typedef struct controllerReadout {
+    Sint16 leftAxis;
+} controllerReadout;
+
+class InputController {
+	private:
+	const Uint8 *keystate;
+	int controllersConnected;
+	SDL_GameController *gameControllers[2];
+	controllerReadout controllerInfo[2];
+
+	std::mutex controllerLock_;
+
+	public:
+	InputController();
+	~InputController();
+	/**
+	 * @brief Can be used to check raw SDL scancode values. This has the same behavior as the previous
+	 * getKeystate function did.
+	 * @return Uint8 array that can be indexed using SDL_Scancode enumerated values.
+	 */
+	const Uint8 *getKeystateRaw();
+	/**
+	 * @brief Shorthand way to check if a keyboard button has been pressed.
+	 * @param scancode - The SDL_Scancode enum value to check for input state.
+	 * @return true if the button described in scancode is pressed down, false otherwise.
+	 */
+	bool getKeyboardInput(SDL_Scancode scancode) const;
+	/**
+	 * @brief Check if a SDL_GameControllerButton has been pressed.
+	 * @param button - The button to poll the input state of. Described by SDL_GameControllerButton.
+	 * @return true if the button is pressed down, false otherwise.
+	 */
+	bool getControllerInput(SDL_GameControllerButton button) const;
+	/**
+	 * @brief Polls for a specific input across keyboard and controller input devices.
+	 * @param input - The input to check for.
+	 * @return true if the GameInput is being pressed by a keyboard or controller. False otherwise.
+	 */
+	bool pollInput(GameInput input);
+
+	/*
+	 (controllerReadout *) getControllers takes an (int) controllerIndex and returns
+	 the associated controllerReadout struct.
+	*/
+	controllerReadout *getControllers(int controllerIndex);
+
+	/*
+	 (int) getControllersConnected returns the number of controllers connected and
+	 detected by the current SDL instance.
+	*/
+	int getControllersConnected();
+
+    /**
+     * @brief Converts a raw SDL scancode value to a GameInput value. @see keyboardInputMap in the GameInstance.cpp
+     * source file to see the complete mapping.
+     * @return GameInput mapped to the raw input, or GameInput::NONE if undefined input received.
+     */
+    GameInput scancodeToInput(SDL_Scancode scancode);
+    /**
+     * @brief Converts a raw SDL button input to the raw input's button map. @see controllerInputMap in the
+     * GameInstance.cpp source file.
+     * @return GameInput mapping to the raw button input. Returns GameInput::NONE if an input is received that is
+     * not defined in the controllerInputMap.
+     */
+    GameInput buttonToInput(SDL_GameControllerButton button);
+    /**
+     * @brief Converts a raw SDL hat input to a GameInput.
+     * @return GameInput mapping to the raw hat value. Returns GameInput::NONE is mapping not found.
+     */
+    GameInput hatToInput(Uint8 hatValue);
+    /**
+     * @brief Closes all active controllers and performs some cleanup.
+     */
+    void resetController();
+
+	void initController();
+};

--- a/src/main/engine/Misc/src/GameInstance.cpp
+++ b/src/main/engine/Misc/src/GameInstance.cpp
@@ -23,41 +23,12 @@
 #include <GameInstance.hpp>
 #include <SceneObject.hpp>
 #include <OpenGlGfxController.hpp>
+#include <InputController.hpp>
 
 std::unique_ptr<GfxController> gfxController;
 std::unique_ptr<AnimationController> animationController;
 std::unique_ptr<PhysicsController> physicsController;
-
-// GameInput maps for input devices
-map<SDL_Scancode, GameInput> keyboardInputMap = {
-    { SDL_SCANCODE_W, GameInput::NORTH      },
-    { SDL_SCANCODE_S, GameInput::SOUTH      },
-    { SDL_SCANCODE_D, GameInput::EAST       },
-    { SDL_SCANCODE_A, GameInput::WEST       },
-    { SDL_SCANCODE_RETURN, GameInput::A     },
-    { SDL_SCANCODE_BACKSPACE, GameInput::B  },
-    { SDL_SCANCODE_BACKSPACE, GameInput::X  },
-    { SDL_SCANCODE_ESCAPE, GameInput::QUIT  }
-};
-
-// GameInput maps for input devices
-map<SDL_GameControllerButton, GameInput> controllerInputMap = {
-    { SDL_CONTROLLER_BUTTON_DPAD_UP, GameInput::NORTH },
-    { SDL_CONTROLLER_BUTTON_DPAD_DOWN, GameInput::SOUTH },
-    { SDL_CONTROLLER_BUTTON_DPAD_RIGHT, GameInput::EAST },
-    { SDL_CONTROLLER_BUTTON_DPAD_LEFT, GameInput::WEST },
-    { SDL_CONTROLLER_BUTTON_A, GameInput::A },
-    { SDL_CONTROLLER_BUTTON_B, GameInput::B },
-    { SDL_CONTROLLER_BUTTON_X, GameInput::X },
-    { SDL_CONTROLLER_BUTTON_BACK, GameInput::QUIT }
-};
-
-map<Uint8, GameInput> hatInputMap = {
-    { SDL_HAT_UP, GameInput::NORTH },
-    { SDL_HAT_DOWN, GameInput::SOUTH },
-    { SDL_HAT_LEFT, GameInput::WEST },
-    { SDL_HAT_RIGHT, GameInput::EAST }
-};
+std::unique_ptr <InputController> inputController;
 
 /*
  (void) startGameInstance uses the passed struct (gameInstanceArgs) args to
@@ -73,7 +44,6 @@ map<Uint8, GameInput> hatInputMap = {
  */
 GameInstance::GameInstance(const StudiousConfig &config): shutdown_(0) {
     luminance = 1.0f;  // Set default values
-    controllersConnected = 0;
     processConfig(config);
     init();
 }
@@ -81,9 +51,8 @@ GameInstance::GameInstance(const StudiousConfig &config): shutdown_(0) {
 void GameInstance::init() {
     initWindow();
     initAudio();
-    initController();
+    inputController->initController();
     initApplication();
-    keystate = SDL_GetKeyboardState(NULL);
 }
 
 /*
@@ -104,65 +73,6 @@ int GameInstance::getHeight() {
 
 vec3 GameInstance::getResolution() {
     return vec3(static_cast<float>(width_), static_cast<float>(height_), 0.0f);
-}
-
-bool GameInstance::getControllerInput(SDL_GameControllerButton button) const {
-    if (!controllersConnected) return false;
-    // Checks if a button was pressed against all connected controllers
-    if (gameControllers[0] == nullptr) {
-        return false;
-    }
-    return SDL_GameControllerGetButton(gameControllers[0], button);
-}
-
-bool GameInstance::getKeyboardInput(SDL_Scancode scancode) const {
-    return keystate[scancode];
-}
-
-bool GameInstance::pollInput(GameInput input) {
-    std::unique_lock<std::mutex> scopeLock(controllerLock_);
-    auto pressed = false;
-    // Check for the target input from either a controller or keyboard (will improve later)
-    SDL_Scancode scancode = SDL_SCANCODE_UNKNOWN;
-    SDL_GameControllerButton button = SDL_CONTROLLER_BUTTON_INVALID;
-    // Reverse the maps and find the corresponding raw input
-    for (auto kbEntry : keyboardInputMap) {
-        // Check if the value is equal and use that keycode
-        if (kbEntry.second == input) {
-            scancode = kbEntry.first;
-            break;
-        }
-    }
-    for (auto cEntry : controllerInputMap) {
-        // Check if the value is equal and use that keycode
-        if (cEntry.second == input) {
-            button = cEntry.first;
-            break;
-        }
-    }
-    // Now finally POLL for events on all devices.
-    pressed |= getControllerInput(button);
-    pressed |= getKeyboardInput(scancode);
-    return pressed;
-}
-
-/*
- (controllerReadout *) getControllers takes an (int) controllerIndex and returns
- the associated controllerReadout struct.
-*/
-controllerReadout* GameInstance::getControllers(int controllerIndex) {
-    controllerInfo[controllerIndex].leftAxis =
-        SDL_GameControllerGetAxis(gameControllers[controllerIndex],
-        SDL_CONTROLLER_AXIS_LEFTY);
-    return &controllerInfo[controllerIndex];
-}
-
-/*
- (int) getControllersConnected returns the number of controllers connected and
- detected by the current SDL instance.
-*/
-int GameInstance::getControllersConnected() {
-    return controllersConnected;
 }
 
 /**
@@ -259,9 +169,6 @@ GameInstance::~GameInstance() {
     printf("GameInstance::~GameInstance\n");
     /* We should empty the protected gfx requests queue */
     runGfxRequests();
-    for (int i = 0; i < controllersConnected; i++) {
-        SDL_GameControllerClose(gameControllers[i]);
-    }
     for (auto &s : loadedSounds_) {
         Mix_FreeChunk(s.second);
     }
@@ -380,7 +287,7 @@ void GameInstance::updateInput() {
             std::unique_lock<std::mutex> scopeLock(inputLock_);
             // printf("Keyboard pressed %d\n", event.key.keysym.scancode);
             // Let's just use the queue as a mailbox for now
-            auto input = scancodeToInput(event.key.keysym.scancode);
+            auto input = inputController->scancodeToInput(event.key.keysym.scancode);
             if (inputQueue_.empty() && input != GameInput::NONE) {
                 inputQueue_.push(input);
             }
@@ -391,7 +298,7 @@ void GameInstance::updateInput() {
             std::unique_lock<std::mutex> scopeLock(inputLock_);
             // printf("Button pressed %d\n", event.jbutton.button);
             // Let's just use the queue as a mailbox for now
-            auto input = buttonToInput(static_cast<SDL_GameControllerButton>(event.jbutton.button));
+            auto input = inputController->buttonToInput(static_cast<SDL_GameControllerButton>(event.jbutton.button));
             if (inputQueue_.empty() && input != GameInput::NONE) {
                 inputQueue_.push(input);
             }
@@ -402,7 +309,7 @@ void GameInstance::updateInput() {
             std::unique_lock<std::mutex> scopeLock(inputLock_);
             // printf("Hat pressed %d\n", event.jhat.value);
             // Let's just use the queue as a mailbox for now
-            auto input = hatToInput(static_cast<Uint8>(event.jhat.value));
+            auto input = inputController->hatToInput(static_cast<Uint8>(event.jhat.value));
             if (inputQueue_.empty() && input != GameInput::NONE) {
                 inputQueue_.push(input);
             }
@@ -412,20 +319,10 @@ void GameInstance::updateInput() {
             shutdown();
         } else if (event.type == SDL_JOYDEVICEADDED || event.type == SDL_JOYDEVICEREMOVED) {
             // Connect to new controllers on the fly...
-            resetController();
-            initController();
+            inputController->resetController();
+            inputController->initController();
         }
     }
-}
-
-GameInput GameInstance::hatToInput(Uint8 hatValue) {
-    auto input = GameInput::NONE;
-    // Check the input map for a game input
-    auto cimit = hatInputMap.find(hatValue);
-    if (cimit != hatInputMap.end()) {
-        input = cimit->second;
-    }
-    return input;
 }
 
 GameInput GameInstance::getInput() {
@@ -719,45 +616,6 @@ int GameInstance::loadSound(string sfxName, string sfxPath) {
     return 0;
 }
 
-/*
- (void) initController attemps to initialize any connected joysticks with the
- current SDL instance.
-
- (void) initController does not return any values.
-*/
-void GameInstance::initController() {
-    std::unique_lock<std::mutex> scopeLock(controllerLock_);
-    int joyFlag = SDL_NumJoysticks();
-    cout << "Number of joysticks connected: " << joyFlag << "\n";
-    if (joyFlag < 1) {
-        cout << "Warning: No Joysticks Detected\n";
-    } else {
-        for (int i = 0; i < joyFlag; i++) {
-            if (SDL_IsGameController(i)) {
-                gameControllers[controllersConnected] = SDL_GameControllerOpen(i);
-                if (gameControllers[controllersConnected] == NULL) {
-                    cerr << "Error: Unable to open game controller - "
-                        << SDL_GetError() << "\n";
-                } else {
-                    controllersConnected++;
-                    return;
-                }
-            }
-        }
-        cout << "No available Xinput joysticks detected!\n";
-    }
-    return;
-}
-
-void GameInstance::resetController() {
-    std::unique_lock<std::mutex> scopeLock(controllerLock_);
-    for (int i = 0; i < controllersConnected; ++i) {
-        SDL_GameControllerClose(gameControllers[i]);
-        gameControllers[i] = nullptr;
-    }
-    controllersConnected = 0;
-}
-
 void GameInstance::initApplication() {
     gfxController_->init();
     configureVsync(vsync_);
@@ -777,30 +635,6 @@ bool GameInstance::waitForProgress(std::function<bool(void)> pred) {
     std::unique_lock<std::mutex> scopeLock(progressLock_);
     progressCv_.wait(scopeLock, [pred, this]() { return pred() || isShutDown(); });
     return !isShutDown();
-}
-
-GameInput GameInstance::scancodeToInput(SDL_Scancode scancode) {
-    auto input = GameInput::NONE;
-    // Check the input map for a game input
-    auto cimit = keyboardInputMap.find(scancode);
-    if (cimit != keyboardInputMap.end()) {
-        input = cimit->second;
-    }
-    return input;
-}
-
-GameInput GameInstance::buttonToInput(SDL_GameControllerButton button) {
-    auto input = GameInput::NONE;
-    // Check the input map for a game input
-    auto cimit = controllerInputMap.find(button);
-    if (cimit != controllerInputMap.end()) {
-        input = cimit->second;
-    }
-    return input;
-}
-
-const Uint8 *GameInstance::getKeystateRaw() {
-    return keystate;
 }
 
 void GameInstance::processConfig(const StudiousConfig &config) {
@@ -832,6 +666,7 @@ void GameInstance::processConfig(const StudiousConfig &config) {
 
     animationController = std::make_unique<AnimationController>();
     physicsController = std::make_unique<PhysicsController>(physThreads);
+    inputController = std::make_unique<InputController>();
 
     // Populate internal pointers to keep things easy
     gfxController_ = gfxController.get();

--- a/src/main/engine/Misc/src/InputController.cpp
+++ b/src/main/engine/Misc/src/InputController.cpp
@@ -1,0 +1,195 @@
+/**
+ * @file inputController.cpp
+ * @author Alec Jackson
+ * @author Christian Galvez
+ * @brief Helper Class to monitor input
+ * @version 0.1
+ * @date 2025
+ *
+ * @copyright Copyright (c) 2025
+ *
+ */
+
+#include <SDL_gamecontroller.h>
+#include <SDL_keyboard.h>
+#include <SDL_scancode.h>
+
+#include <map>
+#include <mutex>
+#include <iostream>
+#include "InputController.hpp"
+
+// GameInput maps for input devices
+std::map<SDL_Scancode, GameInput> keyboardInputMap = {
+    { SDL_SCANCODE_W, GameInput::NORTH      },
+    { SDL_SCANCODE_S, GameInput::SOUTH      },
+    { SDL_SCANCODE_D, GameInput::EAST       },
+    { SDL_SCANCODE_A, GameInput::WEST       },
+    { SDL_SCANCODE_RETURN, GameInput::A     },
+    { SDL_SCANCODE_BACKSPACE, GameInput::B  },
+    { SDL_SCANCODE_BACKSPACE, GameInput::X  },
+    { SDL_SCANCODE_ESCAPE, GameInput::QUIT  }
+};
+
+// GameInput maps for input devices
+std::map<SDL_GameControllerButton, GameInput> controllerInputMap = {
+    { SDL_CONTROLLER_BUTTON_DPAD_UP, GameInput::NORTH },
+    { SDL_CONTROLLER_BUTTON_DPAD_DOWN, GameInput::SOUTH },
+    { SDL_CONTROLLER_BUTTON_DPAD_RIGHT, GameInput::EAST },
+    { SDL_CONTROLLER_BUTTON_DPAD_LEFT, GameInput::WEST },
+    { SDL_CONTROLLER_BUTTON_A, GameInput::A },
+    { SDL_CONTROLLER_BUTTON_B, GameInput::B },
+    { SDL_CONTROLLER_BUTTON_X, GameInput::X },
+    { SDL_CONTROLLER_BUTTON_BACK, GameInput::QUIT }
+};
+
+std::map<Uint8, GameInput> hatInputMap = {
+    { SDL_HAT_UP, GameInput::NORTH },
+    { SDL_HAT_DOWN, GameInput::SOUTH },
+    { SDL_HAT_LEFT, GameInput::WEST },
+    { SDL_HAT_RIGHT, GameInput::EAST }
+};
+
+InputController::InputController(){
+    std::cout << "Creating Controllers!\n";
+    controllersConnected = 0;
+    keystate = SDL_GetKeyboardState(NULL);
+}
+
+InputController::~InputController(){
+    for (int i = 0; i < controllersConnected; i++) {
+        SDL_GameControllerClose(gameControllers[i]);
+    }
+}
+
+const Uint8 *InputController::getKeystateRaw() {
+    return keystate;
+}
+
+bool InputController::getKeyboardInput(SDL_Scancode scancode) const {
+    return keystate[scancode];
+}
+
+bool InputController::getControllerInput(SDL_GameControllerButton button) const {
+    if (!controllersConnected) return false;
+    // Checks if a button was pressed against all connected controllers
+    if (gameControllers[0] == nullptr) {
+        return false;
+    }
+    return SDL_GameControllerGetButton(gameControllers[0], button);
+}
+
+bool InputController::pollInput(GameInput input) {
+    std::unique_lock<std::mutex> scopeLock(controllerLock_);
+    auto pressed = false;
+    // Check for the target input from either a controller or keyboard (will improve later)
+    SDL_Scancode scancode = SDL_SCANCODE_UNKNOWN;
+    SDL_GameControllerButton button = SDL_CONTROLLER_BUTTON_INVALID;
+    // Reverse the maps and find the corresponding raw input
+    for (auto kbEntry : keyboardInputMap) {
+        // Check if the value is equal and use that keycode
+        if (kbEntry.second == input) {
+            scancode = kbEntry.first;
+            break;
+        }
+    }
+    for (auto cEntry : controllerInputMap) {
+        // Check if the value is equal and use that keycode
+        if (cEntry.second == input) {
+            button = cEntry.first;
+            break;
+        }
+    }
+    // Now finally POLL for events on all devices.
+    pressed |= getControllerInput(button);
+    pressed |= getKeyboardInput(scancode);
+    return pressed;
+}
+
+/*
+ (controllerReadout *) getControllers takes an (int) controllerIndex and returns
+ the associated controllerReadout struct.
+*/
+controllerReadout* InputController::getControllers(int controllerIndex) {
+    controllerInfo[controllerIndex].leftAxis =
+        SDL_GameControllerGetAxis(gameControllers[controllerIndex],
+        SDL_CONTROLLER_AXIS_LEFTY);
+    return &controllerInfo[controllerIndex];
+}
+
+/*
+ (int) getControllersConnected returns the number of controllers connected and
+ detected by the current SDL instance.
+*/
+int InputController::getControllersConnected() {
+    return controllersConnected;
+}
+
+/*
+ (void) initController attemps to initialize any connected joysticks with the
+ current SDL instance.
+
+ (void) initController does not return any values.
+*/
+void InputController::initController() {
+    std::unique_lock<std::mutex> scopeLock(controllerLock_);
+    int joyFlag = SDL_NumJoysticks();
+    std::cout << "Number of joysticks connected: " << joyFlag << "\n";
+    if (joyFlag < 1) {
+        std::cout << "Warning: No Joysticks Detected\n";
+    } else {
+        for (int i = 0; i < joyFlag; i++) {
+            if (SDL_IsGameController(i)) {
+                gameControllers[controllersConnected] = SDL_GameControllerOpen(i);
+                if (gameControllers[controllersConnected] == NULL) {
+                    std::cerr << "Error: Unable to open game controller - "
+                        << SDL_GetError() << "\n";
+                } else {
+                    controllersConnected++;
+                    return;
+                }
+            }
+        }
+        std::cout << "No available Xinput joysticks detected!\n";
+    }
+    return;
+}
+
+void InputController::resetController() {
+    std::unique_lock<std::mutex> scopeLock(controllerLock_);
+    for (int i = 0; i < controllersConnected; ++i) {
+        SDL_GameControllerClose(gameControllers[i]);
+        gameControllers[i] = nullptr;
+    }
+    controllersConnected = 0;
+}
+
+GameInput InputController::scancodeToInput(SDL_Scancode scancode) {
+    auto input = GameInput::NONE;
+    // Check the input map for a game input
+    auto cimit = keyboardInputMap.find(scancode);
+    if (cimit != keyboardInputMap.end()) {
+        input = cimit->second;
+    }
+    return input;
+}
+
+GameInput InputController::buttonToInput(SDL_GameControllerButton button) {
+    auto input = GameInput::NONE;
+    // Check the input map for a game input
+    auto cimit = controllerInputMap.find(button);
+    if (cimit != controllerInputMap.end()) {
+        input = cimit->second;
+    }
+    return input;
+}
+
+GameInput InputController::hatToInput(Uint8 hatValue) {
+    auto input = GameInput::NONE;
+    // Check the input map for a game input
+    auto cimit = hatInputMap.find(hatValue);
+    if (cimit != hatInputMap.end()) {
+        input = cimit->second;
+    }
+    return input;
+}


### PR DESCRIPTION
This breaks the input controller off to the InputController class. This stips more logic out of the core gameInstance class and should make it easier to do things like have an input thread in the future. This does currently leave the input queue logic in the gameInstance class. That would probably be good to migrate in the future as well.

Currently this adds no new functionality but it is the first step needed to add more advanced and robust input options

### Considerations
This forks the Input logic into a new class. I think that's just the logical direction, but if there's any objections it's worth raising them now. There will be some short term migration pain.

## QA Checklist

- [ ] I ran `cpplint --linelength=120 --exclude=src/main/opengl --recursive src/main/` and corrected any issues.
- [ ] I added unit tests to relevant code.
- [ ] I can compile using G++.
- [ ] I am passing all unit tests. (`./setupBuild.sh -t`)
